### PR TITLE
fix: assistant response 傳 parent_id 避免排序錯位

### DIFF
--- a/app/apps/rag_chat/handler.py
+++ b/app/apps/rag_chat/handler.py
@@ -59,7 +59,7 @@ async def handle(payload: str, msg: cl.Message) -> None:
     if not payload.strip():
         return
 
-    response = cl.Message(content="")
+    response = cl.Message(content="", parent_id=msg.id)
     sources: list[dict] = []
 
     async for mode, data in _graph.astream(

--- a/app/apps/web_search/handler.py
+++ b/app/apps/web_search/handler.py
@@ -28,7 +28,7 @@ async def handle(payload: str, msg: cl.Message) -> None:
         ).send()
         return
 
-    status = cl.Message(content=f"🔍 搜尋中：**{query}**")
+    status = cl.Message(content=f"🔍 搜尋中：**{query}**", parent_id=msg.id)
     await status.send()
 
     outcome = await search(query)
@@ -58,7 +58,7 @@ async def handle(payload: str, msg: cl.Message) -> None:
         f"=== 查詢 ===\n{query}"
     )
 
-    response = cl.Message(content="")
+    response = cl.Message(content="", parent_id=msg.id)
     await response.send()
     async for chunk in make_llm().astream(prompt):
         content = getattr(chunk, "content", "") or ""


### PR DESCRIPTION
## 問題

第一次切到 Chainlit 原生 command 模式（例如「網頁搜尋」）送第一則訊息時，user message 跟 assistant 回應偶發排序亂掉（AI 回應跑到 user bubble 上方、user bubble 只顯示 command tag 沒顯示文字）。第二則起恢復正常。

## 修法

`rag_chat` 與 `web_search` handler 建立 assistant message 時傳 `parent_id=msg.id`，明確宣告是 user message 的子回覆，Chainlit 走 parent tree 排序而不是時間戳。

## 註記

實際觀察後，發現 stable 容器根本還沒載入這段 code 也自己好了 — 所以這個 bug 其實是 Chainlit 前端 / 瀏覽器 bundle 的一次性 race（初次 fresh load 就不會再發生）。但 `parent_id` 本來就是語意正確寫法（assistant 回覆本就是 user message 的子節點），保留當 defensive coding。

🤖 Generated with [Claude Code](https://claude.com/claude-code)