### PR TITLE
chore: gitignore docker-compose.override.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ public/apps.json
 # Runtime-persisted Chainlit element blobs
 public/elements/
 
+# Deployment-specific compose override (each env maintains its own,
+# e.g. stable sets container_name=*-stable and port 7861:7860)
+docker-compose.override.yml
+
 # IDE
 .vscode/
 .idea/


### PR DESCRIPTION
## 為何

stable 部署需要 override container_name 加 \`-stable\` 後綴跟 port 改 7861:7860，
避免跟 beta 撞名/撞埠。這個檔案本質是環境特定設定，不該進 git。

## 變更

\`.gitignore\` 加一條：
\`\`\`
docker-compose.override.yml
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)