### PR TITLE
feat: M2 — LiteLLM gateway + rag_chat 內部分流

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,13 @@ CHUNK_OVERLAP=100
 TAVILY_API_KEY=
 WEB_SEARCH_TOP_K=5
 
+# ----- LiteLLM (M2 LLM gateway) -----
+# ai-eva 不直連 OpenAI，全部走 LiteLLM proxy
+# LiteLLM container 跑 host network mode（為了能打 Pi5 Tailscale IP）
+LITELLM_API_BASE=http://host.docker.internal:4000/v1
+LITELLM_DEFAULT_MODEL=cloud-fast       # OpenAI gpt-4o-mini，互動主線
+LITELLM_CHEAP_MODEL=local-cheap        # Pi5 Qwen，省錢節點
+
 # ----- Auth (Chainlit password auth) -----
 # ADMIN_PASS 留空 → 關閉 auth（僅本機 dev）；有值 → 啟用登入頁
 # 產生 secret 範例：python3 -c "import secrets; print(secrets.token_urlsafe(48))"

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ public/elements/
 # e.g. stable sets container_name=*-stable and port 7861:7860)
 docker-compose.override.yml
 
+# LiteLLM master config — 含 Tailscale IP，每個部署環境可能不同
+# 若團隊需共用 template，提供 litellm-config.example.yaml 作為樣本
+# litellm-config.yaml
+
 # IDE
 .vscode/
 .idea/

--- a/app/apps/rag_chat/handler.py
+++ b/app/apps/rag_chat/handler.py
@@ -1,4 +1,11 @@
-"""Default RAG chat: retrieve → generate, streaming."""
+"""Default RAG chat: query_rewrite → retrieve → generate, streaming.
+
+M2 起內部分流：
+  query_rewrite  → Pi5 Qwen 把口語化問句改寫成檢索友善的 query（省 OpenAI 額度）
+  retrieve       → Chroma 相似度搜尋（純本地、無 LLM）
+  generate       → OpenAI 綜合 RAG 結果產生最終回應（streaming）
+"""
+import logging
 from typing import List, TypedDict
 
 import chainlit as cl
@@ -6,16 +13,48 @@ from langgraph.graph import END, StateGraph
 
 from app.core.llm import make_llm
 from app.core.rag import retrieve
+from app.settings import LITELLM_CHEAP_MODEL
+
+logger = logging.getLogger(__name__)
 
 
 class State(TypedDict, total=False):
     question: str
+    rewritten: str
     docs: List[dict]
     answer: str
 
 
+def _query_rewrite(state: State) -> State:
+    """用 cheap model（Pi5 Qwen）把口語問題改寫成適合 retrieve 的 query。
+
+    失敗時退回原問題（LiteLLM 的 fallback 也會自動接手回 cloud-fast）。"""
+    question = state["question"]
+    prompt = (
+        "把下列使用者口語問題，改寫成更精確的「檢索查詢」。要求：\n"
+        "- 保留所有專有名詞 / 關鍵字\n"
+        "- 移除冗詞、贅字、語助詞\n"
+        "- 不要回答問題本身\n"
+        "- 30 字內、單行\n"
+        "- 只輸出改寫後的 query，不加任何說明\n\n"
+        f"原問題：{question}\n"
+        "改寫後："
+    )
+    try:
+        llm = make_llm(alias=LITELLM_CHEAP_MODEL, temperature=0, streaming=False)
+        rewritten = (llm.invoke(prompt).content or "").strip().split("\n")[0]
+        if not rewritten or len(rewritten) > 200:
+            rewritten = question
+    except Exception as e:
+        logger.warning("query_rewrite failed (%s); fall back to raw question", e)
+        rewritten = question
+    logger.info("query_rewrite: %r → %r", question, rewritten)
+    return {"rewritten": rewritten}
+
+
 def _retrieve(state: State) -> State:
-    return {"docs": retrieve(state["question"])}
+    query = state.get("rewritten") or state["question"]
+    return {"docs": retrieve(query)}
 
 
 def _generate(state: State) -> State:
@@ -38,15 +77,17 @@ def _generate(state: State) -> State:
         f"=== 參考資料 ===\n{context}\n\n"
         f"=== 問題 ===\n{state['question']}"
     )
-    resp = make_llm().invoke(prompt)
+    resp = make_llm().invoke(prompt)   # 走預設 alias (cloud-fast / OpenAI)
     return {"answer": resp.content}
 
 
 def _build_graph():
     g = StateGraph(State)
+    g.add_node("query_rewrite", _query_rewrite)
     g.add_node("retrieve", _retrieve)
     g.add_node("generate", _generate)
-    g.set_entry_point("retrieve")
+    g.set_entry_point("query_rewrite")
+    g.add_edge("query_rewrite", "retrieve")
     g.add_edge("retrieve", "generate")
     g.add_edge("generate", END)
     return g.compile()
@@ -71,7 +112,10 @@ async def handle(payload: str, msg: cl.Message) -> None:
             if retrieve_out:
                 sources = retrieve_out.get("docs", [])
         elif mode == "messages":
-            chunk, _meta = data
+            chunk, meta = data
+            # 只串 generate 節點的 token（query_rewrite 的中間結果不外露）
+            if meta.get("langgraph_node") != "generate":
+                continue
             content = getattr(chunk, "content", "") or ""
             if content:
                 await response.stream_token(content)

--- a/app/core/llm.py
+++ b/app/core/llm.py
@@ -1,13 +1,28 @@
+"""
+LLM factory — 所有 LLM 呼叫都走 LiteLLM proxy（M2 起）。
+
+使用方式：
+    llm = make_llm()                        # 預設 alias (cloud-fast / OpenAI)
+    llm = make_llm(alias="local-cheap")     # Pi5 Qwen
+    llm = make_llm(alias="local-cheap", temperature=0)
+
+alias 是 litellm-config.yaml 裡的 model_name；新增 provider 改 config，這層不動。
+"""
 from langchain_openai import ChatOpenAI
 
-from app.settings import LLM_MODEL, OPENAI_API_BASE, OPENAI_API_KEY
+from app.settings import LITELLM_API_BASE, LITELLM_DEFAULT_MODEL
 
 
-def make_llm(temperature: float = 0.2, streaming: bool = True) -> ChatOpenAI:
+def make_llm(
+    *,
+    alias: str | None = None,
+    temperature: float = 0.2,
+    streaming: bool = True,
+) -> ChatOpenAI:
     return ChatOpenAI(
-        model=LLM_MODEL,
-        api_key=OPENAI_API_KEY,
-        base_url=OPENAI_API_BASE,
+        model=alias or LITELLM_DEFAULT_MODEL,
+        api_key="litellm-no-auth",   # LiteLLM 未設 master key，dummy 即可
+        base_url=LITELLM_API_BASE,
         temperature=temperature,
         streaming=streaming,
     )

--- a/app/settings.py
+++ b/app/settings.py
@@ -19,3 +19,7 @@ CHUNK_OVERLAP = int(os.getenv("CHUNK_OVERLAP", "100"))
 
 TAVILY_API_KEY = os.getenv("TAVILY_API_KEY", "").strip()
 WEB_SEARCH_TOP_K = int(os.getenv("WEB_SEARCH_TOP_K", "5"))
+
+LITELLM_API_BASE = os.getenv("LITELLM_API_BASE", "http://host.docker.internal:4000/v1")
+LITELLM_DEFAULT_MODEL = os.getenv("LITELLM_DEFAULT_MODEL", "cloud-fast")
+LITELLM_CHEAP_MODEL = os.getenv("LITELLM_CHEAP_MODEL", "local-cheap")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      litellm:
+        condition: service_started
     env_file:
       - .env
     ports:
@@ -34,6 +36,19 @@ services:
       - ./public:/app/public
     extra_hosts:
       - "host.docker.internal:host-gateway"
+
+  litellm:
+    image: ghcr.io/berriai/litellm:main-stable
+    container_name: ai-eva-litellm
+    restart: unless-stopped
+    # 只傳真正需要的 env，不要 inherit Chainlit 的 DATABASE_URL（否則 LiteLLM 會把
+    # 它當自己的 state DB 去做 prisma migrate）
+    environment:
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+    command: ["--config", "/app/config.yaml", "--port", "4000"]
+    volumes:
+      - ./litellm-config.yaml:/app/config.yaml:ro
+    network_mode: host    # 為了能直接打 Pi5 Tailscale IP (100.74.6.41)
 
 volumes:
   ai_eva_pgdata:

--- a/docs/litellm-setup.md
+++ b/docs/litellm-setup.md
@@ -1,0 +1,112 @@
+# LiteLLM Gateway Setup（M2 紀錄）
+
+> 把 ai-eva 從「直連 OpenAI」改成「全部走 LiteLLM proxy」。LiteLLM 路由到 OpenAI（雲端互動主線）或 Pi5 Ollama（本地省錢節點），失敗自動 fallback。
+> 為 [#12](https://github.com/towNingtek/ai-eva/issues/12) 的執行紀錄。
+
+## 拓樸
+
+```
+[ai-eva container]
+  langchain_openai.ChatOpenAI(base_url="http://host.docker.internal:4000/v1")
+       ↓
+[ai-eva-litellm container] (host network mode)
+  /v1/chat/completions  ──── alias 路由 ────┐
+                                          │
+       ┌──────────────── openai/gpt-4o-mini (cloud-fast / default)
+       │                       ↓
+       │                  api.openai.com
+       │
+       └──────────────── ollama_chat/qwen2.5:3b (local-cheap)
+                              ↓ via Tailscale mesh VPN
+                         http://100.74.6.41:11434 (Pi5)
+                              ↓
+                         Ollama → Qwen 2.5:3b-q4
+```
+
+## 三個 model 別名
+
+`litellm-config.yaml`：
+
+| alias | 對應 provider/model | 用途 |
+|---|---|---|
+| `cloud-fast` | `openai/gpt-4o-mini` | 互動主線、品質高、快 |
+| `local-cheap` | `ollama_chat/qwen2.5:3b-instruct-q4_K_M` (Pi5) | 被動推播、預處理節點、省 OpenAI 額度 |
+| `default` | `openai/gpt-4o-mini` | 沒指定 model 的 client 用 |
+
+Router fallback：`local-cheap` 失敗 → 自動回 `cloud-fast`（驗證過：停 Pi5 ollama，使用者依然有回應）。
+
+## 重要設定點
+
+### docker-compose litellm service
+
+```yaml
+litellm:
+  image: ghcr.io/berriai/litellm:main-stable
+  network_mode: host             # ← 為了打 Pi5 Tailscale IP
+  environment:
+    OPENAI_API_KEY: ${OPENAI_API_KEY}
+  volumes:
+    - ./litellm-config.yaml:/app/config.yaml:ro
+  command: ["--config", "/app/config.yaml", "--port", "4000"]
+```
+
+**注意**：**不要** `env_file: - .env`。否則 LiteLLM 會 inherit Chainlit 的 `DATABASE_URL`，把 prisma migrate 跑進 Chainlit 的 PG，污染對方 schema。
+
+### `network_mode: host` 為什麼必要
+
+LiteLLM 要打 Pi5 Tailscale IP `100.74.6.41`。如果 LiteLLM 在 docker bridge 網路（預設），bridge 不在 Tailscale 的 routing table 上，會打不到。host network 直接共用 cms-server 的網路 stack，跟 host 一樣能走 Tailscale。
+
+### ai-eva 端設定
+
+```python
+# app/settings.py
+LITELLM_API_BASE = os.getenv("LITELLM_API_BASE", "http://host.docker.internal:4000/v1")
+LITELLM_DEFAULT_MODEL = os.getenv("LITELLM_DEFAULT_MODEL", "cloud-fast")
+LITELLM_CHEAP_MODEL = os.getenv("LITELLM_CHEAP_MODEL", "local-cheap")
+
+# app/core/llm.py
+def make_llm(*, alias=None, temperature=0.2, streaming=True):
+    return ChatOpenAI(
+        model=alias or LITELLM_DEFAULT_MODEL,
+        api_key="litellm-no-auth",
+        base_url=LITELLM_API_BASE,
+        ...
+    )
+```
+
+### rag_chat 內部分流
+
+```python
+def _build_graph():
+    g.add_node("query_rewrite", _query_rewrite)   # alias=local-cheap (Pi5)
+    g.add_node("retrieve",      _retrieve)         # 純本地 Chroma
+    g.add_node("generate",      _generate)         # alias=default (OpenAI)
+    g.set_entry_point("query_rewrite")
+    g.add_edge("query_rewrite", "retrieve")
+    g.add_edge("retrieve", "generate")
+```
+
+使用者問問題 → Pi5 改寫 query → Chroma 檢索 → OpenAI 產生答案。**前端 UI 零變化**。
+
+## 已踩過的坑（給未來自己）
+
+1. **LiteLLM container 不要 inherit Chainlit 的 .env** — `DATABASE_URL` 會讓它跑 prisma migrate 進錯的 DB。用 `environment:` 顯式列必要 env。
+2. **`network_mode: host` 跟 `ports:` 衝突** — host mode 下 published ports 會被忽略（compose 會印 warning）。要嘛 host mode、要嘛 bridge + ports，不能同時。
+3. **`api_base` 給 ollama_chat 要寫完整 IP**（如 Tailscale `100.x.y.z:11434`），不要塞 hostname（除非有 DNS 解析能力）。
+4. **LiteLLM 啟動慢** — 從 container start 到 port 4000 listen 約 30~50 秒（prisma migrate + module imports）。容器看似活著但 health check 不過是正常，等就好。
+
+## 對 ai-eva 使用者的影響
+
+**前端 UI 零變化**。內部變化：
+
+- 任何 LLM 呼叫都走 LiteLLM，可在 cms-server 後台統一看 log / cost
+- 之後想加 Claude / Gemini，只要 `litellm-config.yaml` 多一段、ai-eva 不用改一行
+- Pi5 掛了使用者不會中斷服務（自動 fallback）
+
+## 後續里程碑
+
+- **M2.5（可選）**：LiteLLM virtual keys（不同 surface 分流帳單）、預算上限、cost dashboard、多 OpenAI key 負載均衡
+- **M3 LINE Bot Adapter**：LINE webhook → 同一個 dispatch → 自動透過 LiteLLM 走 LLM
+- **M4 RabbitMQ + 被動推播**：cron worker 也透過 LiteLLM（或直接 call Pi5 ollama，看任務性質）
+
+詳見 [roadmap #8](https://github.com/towNingtek/ai-eva/issues/8)。

--- a/litellm-config.yaml
+++ b/litellm-config.yaml
@@ -1,0 +1,30 @@
+# LiteLLM proxy config — ai-eva LLM gateway
+#
+# 三個 model 別名：
+#   cloud-fast  → OpenAI gpt-4o-mini（互動主線、快速、品質高）
+#   local-cheap → Pi5 Qwen 2.5:3b-q4 via Tailscale（被動推播 / 省錢節點）
+#   default     → 同 cloud-fast（給沒指定 model 的 client 用）
+#
+# Fallback：local-cheap 失敗（Pi5 掛了 / Tailscale 斷）→ 自動回 cloud-fast
+
+model_list:
+  - model_name: cloud-fast
+    litellm_params:
+      model: openai/gpt-4o-mini
+      api_key: os.environ/OPENAI_API_KEY
+
+  - model_name: local-cheap
+    litellm_params:
+      model: ollama_chat/qwen2.5:3b-instruct-q4_K_M
+      api_base: http://100.74.6.41:11434   # Pi5 Tailscale IP
+
+  - model_name: default
+    litellm_params:
+      model: openai/gpt-4o-mini
+      api_key: os.environ/OPENAI_API_KEY
+
+router_settings:
+  fallbacks:
+    - local-cheap: ["cloud-fast"]
+  num_retries: 1
+  timeout: 60


### PR DESCRIPTION
Closes #12.

把 ai-eva 從「直連 OpenAI」升級成「全部走 LiteLLM proxy」。LiteLLM 路由到 cloud-fast (OpenAI gpt-4o-mini) 或 local-cheap (Pi5 Qwen via Tailscale)，後者失敗自動 fallback 到前者。

## 主要變動

- \`docker-compose.yml\`：新增 \`litellm\` service（host network 為了打 Pi5 Tailscale IP）
- \`litellm-config.yaml\`：三個 model 別名（cloud-fast / local-cheap / default）+ router fallback
- \`app/core/llm.py\`：\`make_llm()\` 改成走 LiteLLM base_url，接收 alias 參數
- \`app/settings.py\`：新增 LiteLLM 相關 env
- \`app/apps/rag_chat/handler.py\`：LangGraph 從「retrieve → generate」拆成「query_rewrite (Pi5) → retrieve → generate (OpenAI)」
- \`docs/litellm-setup.md\`：完整操作紀錄

## 已實測（beta 站）

| 驗證項 | 結果 |
|---|---|
| cloud-fast / local-cheap 兩條 provider 路徑 | ✅ 都通 |
| Pi5 ollama 停掉 → 打 local-cheap → fallback | ✅ 自動回 gpt-4o-mini，使用者有回應 |
| 使用者 UI 變化 | ✅ 零變化 |
| 一個 RAG 問題觸發兩條 LLM call | ✅ log 看到 query_rewrite (Pi5) + generate (OpenAI) |

## Stable 還沒部署

merge 後我會：
1. stable dir \`git pull\`
2. 把 \`litellm-config.yaml\` 跟 \`.env\` 對到 stable
3. \`docker compose -p ai-eva-stable build ai-eva\` 跟 \`up -d litellm\`
4. 確認 eva.4impact.cc 不中斷

🤖 Generated with [Claude Code](https://claude.com/claude-code)