### PR TITLE
feat: M3 — LINE Bot Adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,14 @@ LITELLM_CHEAP_MODEL=local-cheap        # Pi5 Qwen，省錢節點
 # ai-eva 透過 LITELLM_API_KEY 打 LiteLLM；Admin UI 用 admin / <master> 登入
 LITELLM_MASTER_KEY=
 LITELLM_API_KEY=
+# 各 surface 各自一把 virtual key（透過 LiteLLM Admin UI 或 /key/generate API 發）
+LITELLM_LINE_KEY=
+
+# ----- LINE Bot (M3) -----
+# LINE Developers Console → Messaging API channel
+# 空值 → /webhook/line 端點回 503，不啟用
+LINE_CHANNEL_SECRET=
+LINE_CHANNEL_ACCESS_TOKEN=
 
 # ----- Auth (Chainlit password auth) -----
 # ADMIN_PASS 留空 → 關閉 auth（僅本機 dev）；有值 → 啟用登入頁

--- a/app/core/llm.py
+++ b/app/core/llm.py
@@ -16,12 +16,18 @@ from app.settings import LITELLM_API_BASE, LITELLM_API_KEY, LITELLM_DEFAULT_MODE
 def make_llm(
     *,
     alias: str | None = None,
+    api_key: str | None = None,
     temperature: float = 0.2,
     streaming: bool = True,
 ) -> ChatOpenAI:
+    """LiteLLM 後 ChatOpenAI factory。
+
+    `api_key` 可以傳指定 virtual key（例如 LINE bot 用獨立 key 帳單分離），
+    不傳就走預設的 LITELLM_API_KEY（通常是 master key 或 ai-eva-web 的 virtual key）。
+    """
     return ChatOpenAI(
         model=alias or LITELLM_DEFAULT_MODEL,
-        api_key=LITELLM_API_KEY or "litellm-no-auth",
+        api_key=api_key or LITELLM_API_KEY or "litellm-no-auth",
         base_url=LITELLM_API_BASE,
         temperature=temperature,
         streaming=streaming,

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 
@@ -8,6 +9,7 @@ from chainlit.data.sql_alchemy import SQLAlchemyDataLayer
 from app.apps._registry import chainlit_commands, default_app, discover, get_by_id
 from app.core.storage import LocalStorageClient
 from app.settings import ROOT
+from app.surfaces import line as line_surface  # 註冊 /webhook/line route
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +32,14 @@ if ADMIN_PASS:
 
 
 discover()
+
+# 啟動時建 line_users 表（給 LINE follow event 紀錄用）。Chainlit 沒 on_app_startup
+# decorator，這裡直接用 asyncio fire-and-forget。
+try:
+    asyncio.get_event_loop().create_task(line_surface.ensure_line_table())
+except RuntimeError:
+    # 沒 loop 就同步跑一次（import 階段）
+    asyncio.run(line_surface.ensure_line_table())
 
 
 async def _register_commands():

--- a/app/settings.py
+++ b/app/settings.py
@@ -15,5 +15,9 @@ WEB_SEARCH_TOP_K = int(os.getenv("WEB_SEARCH_TOP_K", "5"))
 
 LITELLM_API_BASE = os.getenv("LITELLM_API_BASE", "http://host.docker.internal:4000/v1")
 LITELLM_API_KEY = os.getenv("LITELLM_API_KEY", "").strip()
+LITELLM_LINE_KEY = os.getenv("LITELLM_LINE_KEY", "").strip()
 LITELLM_DEFAULT_MODEL = os.getenv("LITELLM_DEFAULT_MODEL", "cloud-fast")
 LITELLM_CHEAP_MODEL = os.getenv("LITELLM_CHEAP_MODEL", "local-cheap")
+
+LINE_CHANNEL_SECRET = os.getenv("LINE_CHANNEL_SECRET", "").strip()
+LINE_CHANNEL_ACCESS_TOKEN = os.getenv("LINE_CHANNEL_ACCESS_TOKEN", "").strip()

--- a/app/surfaces/line.py
+++ b/app/surfaces/line.py
@@ -1,0 +1,199 @@
+"""LINE Messaging API adapter — M3。
+
+掛在 Chainlit 的 FastAPI app 上的 `/webhook/line`：
+- 收 LINE 事件 → 簽章驗證 → 處理 message / follow / unfollow
+- message → LiteLLM (走 LITELLM_LINE_KEY 獨立 virtual key) → reply
+- follow → 把 userId 存進 PG `line_users`（給 M4 push 用）
+
+push helper `push_to_user()` 預先寫好，等 M4 cron worker 來呼叫。
+"""
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import os
+from typing import Optional
+
+import asyncpg
+import httpx
+from chainlit.server import app as fastapi_app
+from fastapi import HTTPException, Request
+
+from app.core.llm import make_llm
+from app.settings import (
+    LINE_CHANNEL_ACCESS_TOKEN,
+    LINE_CHANNEL_SECRET,
+    LITELLM_LINE_KEY,
+)
+
+logger = logging.getLogger(__name__)
+
+_LINE_API = "https://api.line.me/v2/bot"
+_DATABASE_URL = os.getenv("DATABASE_URL", "")
+
+
+def _pg_url() -> str:
+    """SQLAlchemy URL → asyncpg-compatible URL."""
+    return _DATABASE_URL.replace("postgresql+asyncpg://", "postgresql://")
+
+
+async def ensure_line_table() -> None:
+    """啟動時跑：建 line_users 表（沒就建，有就跳過）。"""
+    if not _DATABASE_URL:
+        logger.warning("DATABASE_URL not set; LINE follow events won't be persisted")
+        return
+    conn = await asyncpg.connect(_pg_url())
+    try:
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS line_users (
+                user_id       TEXT PRIMARY KEY,
+                display_name  TEXT,
+                followed_at   TIMESTAMPTZ DEFAULT NOW(),
+                unfollowed_at TIMESTAMPTZ,
+                metadata      JSONB DEFAULT '{}'::jsonb
+            )
+            """
+        )
+    finally:
+        await conn.close()
+
+
+async def _save_follow(user_id: str) -> None:
+    if not _DATABASE_URL:
+        return
+    conn = await asyncpg.connect(_pg_url())
+    try:
+        await conn.execute(
+            """
+            INSERT INTO line_users (user_id, followed_at, unfollowed_at)
+            VALUES ($1, NOW(), NULL)
+            ON CONFLICT (user_id) DO UPDATE SET
+                followed_at = NOW(),
+                unfollowed_at = NULL
+            """,
+            user_id,
+        )
+    finally:
+        await conn.close()
+
+
+async def _mark_unfollow(user_id: str) -> None:
+    if not _DATABASE_URL:
+        return
+    conn = await asyncpg.connect(_pg_url())
+    try:
+        await conn.execute(
+            "UPDATE line_users SET unfollowed_at = NOW() WHERE user_id = $1",
+            user_id,
+        )
+    finally:
+        await conn.close()
+
+
+async def _line_reply(reply_token: str, text: str) -> None:
+    if not LINE_CHANNEL_ACCESS_TOKEN:
+        logger.warning("LINE access token missing; skipping reply")
+        return
+    async with httpx.AsyncClient(timeout=10) as cx:
+        r = await cx.post(
+            f"{_LINE_API}/message/reply",
+            headers={"Authorization": f"Bearer {LINE_CHANNEL_ACCESS_TOKEN}"},
+            json={"replyToken": reply_token, "messages": [{"type": "text", "text": text[:5000]}]},
+        )
+        if r.status_code >= 400:
+            logger.error("LINE reply failed: %s %s", r.status_code, r.text[:200])
+
+
+async def push_to_user(user_id: str, text: str) -> bool:
+    """M4 cron worker 會 import 來用。沒有 access token 就 no-op。"""
+    if not LINE_CHANNEL_ACCESS_TOKEN:
+        return False
+    async with httpx.AsyncClient(timeout=10) as cx:
+        r = await cx.post(
+            f"{_LINE_API}/message/push",
+            headers={"Authorization": f"Bearer {LINE_CHANNEL_ACCESS_TOKEN}"},
+            json={"to": user_id, "messages": [{"type": "text", "text": text[:5000]}]},
+        )
+        if r.status_code >= 400:
+            logger.error("LINE push failed: %s %s", r.status_code, r.text[:200])
+            return False
+    return True
+
+
+def _verify_signature(body: bytes, signature: str) -> bool:
+    if not LINE_CHANNEL_SECRET or not signature:
+        return False
+    expected = base64.b64encode(
+        hmac.new(LINE_CHANNEL_SECRET.encode(), body, hashlib.sha256).digest()
+    ).decode()
+    return hmac.compare_digest(signature, expected)
+
+
+def _llm_answer_sync(text: str) -> str:
+    return make_llm(
+        api_key=LITELLM_LINE_KEY or None,  # 帳單算進 line-bot virtual key
+        streaming=False,
+    ).invoke(text).content
+
+
+@fastapi_app.post("/webhook/line")
+async def line_webhook(req: Request):
+    if not LINE_CHANNEL_SECRET:
+        raise HTTPException(503, "LINE not configured (LINE_CHANNEL_SECRET missing)")
+
+    body = await req.body()
+    signature = req.headers.get("x-line-signature", "")
+    if not _verify_signature(body, signature):
+        logger.warning("LINE webhook bad signature")
+        raise HTTPException(403, "Invalid signature")
+
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError:
+        raise HTTPException(400, "Bad JSON")
+
+    for event in data.get("events", []):
+        await _handle_event(event)
+
+    return {"ok": True}
+
+
+async def _handle_event(event: dict) -> None:
+    evt_type = event.get("type")
+    source = event.get("source", {}) or {}
+    user_id: Optional[str] = source.get("userId")
+
+    if evt_type == "follow" and user_id:
+        await _save_follow(user_id)
+        logger.info("LINE follow: %s", user_id)
+        return
+
+    if evt_type == "unfollow" and user_id:
+        await _mark_unfollow(user_id)
+        logger.info("LINE unfollow: %s", user_id)
+        return
+
+    if evt_type != "message":
+        return
+
+    msg = event.get("message", {}) or {}
+    if msg.get("type") != "text":
+        return
+
+    text = (msg.get("text") or "").strip()
+    reply_token = event.get("replyToken")
+    if not text or not reply_token:
+        return
+
+    logger.info("LINE message from %s: %r", user_id, text[:80])
+
+    try:
+        answer = (await asyncio.to_thread(_llm_answer_sync, text)).strip()
+    except Exception as e:
+        logger.exception("LLM call failed for LINE message")
+        answer = f"⚠️ 處理失敗，請稍後再試（{type(e).__name__}）"
+
+    await _line_reply(reply_token, answer)

--- a/docs/line-bot-setup.md
+++ b/docs/line-bot-setup.md
@@ -1,0 +1,136 @@
+# LINE Bot Setup（M3）
+
+> 把 ai-eva 開到 LINE 上 — 使用者傳訊息 → AI 回應。Push（主動推播）基礎建設預備好，等 M4 cron worker 接。
+> 為 [#8 roadmap M3](https://github.com/towNingtek/ai-eva/issues/8) 的執行紀錄。
+
+## 拓樸
+
+```
+[使用者手機 LINE]
+   ↓ 加 bot 為好友 / 傳訊息
+[LINE 伺服器]
+   ↓ HTTPS POST + X-Line-Signature header
+[https://eva.4impact.cc/webhook/line]
+   ↓ Chainlit 的 FastAPI app（同 :7861）
+[app/surfaces/line.py]
+   ├─ 簽章驗證（HMAC-SHA256 with channel secret）
+   ├─ follow event   → INSERT 進 line_users PG 表
+   ├─ unfollow event → 標記 unfollowed_at
+   └─ message event  → LiteLLM (LITELLM_LINE_KEY) → reply API
+                          ↓
+                       OpenAI gpt-4o-mini (預設) / Pi5 Qwen
+```
+
+## LINE Developer Console 設定
+
+1. https://developers.line.biz → Provider → 新建 Messaging API channel
+2. 設定 → Basic settings：
+   - 拿 **Channel secret**
+3. 設定 → Messaging API：
+   - 發 **Channel access token (long-lived)**
+   - Webhook URL: `https://eva.4impact.cc/webhook/line`
+   - Use webhook: **Enabled**
+   - Auto-reply messages: **Disabled**（不然 LINE 預設的「感謝您」會搶在前面）
+   - Greeting messages: 可選
+
+## env vars
+
+```bash
+# ai-eva .env
+LINE_CHANNEL_SECRET=<from console>
+LINE_CHANNEL_ACCESS_TOKEN=<from console>
+
+# 從 LiteLLM Admin UI 或 API 發一把限定 cloud-fast + local-cheap、月預算 $5 的 virtual key
+LITELLM_LINE_KEY=sk-xxxxxxxxx
+```
+
+發 virtual key（範例指令，beta 跟 stable 各發一把不共用）：
+
+```bash
+MASTER_KEY=<from .env LITELLM_MASTER_KEY>
+curl -X POST http://localhost:4000/key/generate \
+  -H "Authorization: Bearer $MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "models": ["cloud-fast", "local-cheap"],
+    "max_budget": 5,
+    "duration": "30d",
+    "rpm_limit": 60,
+    "key_alias": "line-bot-stable",
+    "metadata": {"surface": "line-bot"}
+  }'
+```
+
+## 驗收測試（curl）
+
+```bash
+SECRET=$LINE_CHANNEL_SECRET
+URL=http://localhost:7860/webhook/line   # 或 stable: eva.4impact.cc
+
+# 1. 沒簽章 → 403
+curl -s -o /dev/null -w "%{http_code}\n" -X POST $URL -d '{"events":[]}'
+
+# 2. 假簽章 → 403
+curl -s -o /dev/null -w "%{http_code}\n" -X POST $URL \
+  -H "x-line-signature: bad" -d '{"events":[]}'
+
+# 3. 正確簽章 + 空 events → 200
+BODY='{"events":[]}'
+SIG=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "$SECRET" -binary | base64)
+curl -s -o /dev/null -w "%{http_code}\n" -X POST $URL \
+  -H "x-line-signature: $SIG" -d "$BODY"
+
+# 4. 假 follow event → 200，並進 PG
+BODY='{"events":[{"type":"follow","source":{"userId":"Utest1","type":"user"}}]}'
+SIG=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "$SECRET" -binary | base64)
+curl -s -o /dev/null -w "%{http_code}\n" -X POST $URL \
+  -H "x-line-signature: $SIG" -d "$BODY"
+
+# 看 PG
+docker exec ai-eva-postgres psql -U chainlit -d chainlit \
+  -c "SELECT user_id, followed_at, unfollowed_at FROM line_users;"
+```
+
+## 從手機實測
+
+1. LINE Console Messaging API 頁面有 QR code，掃描加 bot 為好友
+2. 加完應該在 PG `line_users` 看到 follow event 紀錄
+3. 傳訊息「你好」→ 10 秒內收到 OpenAI gpt-4o-mini 回應
+4. LiteLLM Admin UI (`http://localhost:4001/ui` for stable) → Spend Tracking → `line-bot-stable` key 的累計 cost 增加
+
+## 已踩過的坑
+
+- **Auto-reply 沒關** → 你的 reply 會被 LINE 預設「感謝您加為好友」搶先送出。Console 一定要關掉 auto-reply
+- **Webhook 不能用 HTTP**（LINE 強制 HTTPS） → stable 走 nginx + Let's Encrypt 自動解決；beta 要用 Cloudflare tunnel
+- **Channel secret 跟 access token 是兩個不同欄位**，別搞混（secret 短 32 字元；token 很長一串）
+- **`reply_token` 只能用一次**，30 秒內 reply 否則失效
+
+## Push（主動推播）— M3 預備好給 M4 用
+
+```python
+# app/surfaces/line.py 有
+async def push_to_user(user_id: str, text: str) -> bool: ...
+```
+
+M4 cron worker 流程會是：
+
+```python
+from app.surfaces.line import push_to_user
+import asyncpg
+
+# 1. 從 PG 拿要 push 的 user list
+conn = await asyncpg.connect(pg_url)
+rows = await conn.fetch("SELECT user_id FROM line_users WHERE unfollowed_at IS NULL")
+
+# 2. 推給每一個
+for r in rows:
+    await push_to_user(r["user_id"], "🌅 早安！今天 GitHub 摘要：...")
+```
+
+M3 本身**不主動 push**，只把基礎建設打好。
+
+## 後續
+
+- **M3.1**（之後）：從 LINE 觸發工具（`/search xxx` → web_search、`/compare` → hello_world）
+- **M3.2**（之後）：多 LINE channel + 多 virtual key，每個給不同客戶 / 不同 preset
+- **M4**：cron + RabbitMQ → push 出去


### PR DESCRIPTION
Roadmap [#8](https://github.com/towNingtek/ai-eva/issues/8) M3。

開 LINE 入口、跟 Chainlit web 平行使用 ai-eva 後端。Push 基礎建設預備好給 M4 用。

## 已實測

| 測試 | 結果 |
|---|---|
| 無簽章 → 403 | ✓ |
| 假簽章 → 403 | ✓ |
| 正確簽章 → 200 | ✓ |
| follow event → 進 PG line_users | ✓ |

## 範圍宣告

v1 只做 reply。Push（主動推播）M4 用，本 PR 寫好 helper。

🤖 Generated with [Claude Code](https://claude.com/claude-code)