### PR TITLE
feat: 接 NVIDIA NIM 5 個免費 model + 修 hello_world auth + LINE userId 補強

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,11 @@ LITELLM_API_KEY=
 # 各 surface 各自一把 virtual key（透過 LiteLLM Admin UI 或 /key/generate API 發）
 LITELLM_LINE_KEY=
 
+# ----- NVIDIA NIM (M2.5 多模型對照用，免費 endpoint) -----
+# 註冊：https://build.nvidia.com → API Keys（要手機 OTP 驗證）
+# 配額：40 RPM；不穩、隨時可能變動，只用在 hello_world 對照
+NVIDIA_API_KEY=
+
 # ----- LINE Bot (M3) -----
 # LINE Developers Console → Messaging API channel
 # 空值 → /webhook/line 端點回 503，不啟用

--- a/app/apps/hello_world/handler.py
+++ b/app/apps/hello_world/handler.py
@@ -13,7 +13,7 @@ import chainlit as cl
 import httpx
 
 from app.core.llm import make_llm
-from app.settings import LITELLM_API_BASE
+from app.settings import LITELLM_API_BASE, LITELLM_API_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -36,9 +36,10 @@ def _icon_for(alias: str) -> str:
 
 
 async def _list_aliases() -> list[str]:
+    headers = {"Authorization": f"Bearer {LITELLM_API_KEY}"} if LITELLM_API_KEY else {}
     try:
         async with httpx.AsyncClient(timeout=3) as cx:
-            r = await cx.get(f"{LITELLM_API_BASE}/models")
+            r = await cx.get(f"{LITELLM_API_BASE}/models", headers=headers)
             r.raise_for_status()
             ids = [m["id"] for m in r.json().get("data", [])]
     except Exception as e:

--- a/app/surfaces/line.py
+++ b/app/surfaces/line.py
@@ -190,6 +190,10 @@ async def _handle_event(event: dict) -> None:
 
     logger.info("LINE message from %s: %r", user_id, text[:80])
 
+    # 順手把 message sender 也 upsert 進 line_users（如果之前 follow 沒抓到）
+    if user_id:
+        await _save_follow(user_id)
+
     try:
         answer = (await asyncio.to_thread(_llm_answer_sync, text)).strip()
     except Exception as e:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,7 @@ services:
     # 只傳真正需要的 env，不要 inherit Chainlit 的 DATABASE_URL
     environment:
       OPENAI_API_KEY: ${OPENAI_API_KEY}
+      NVIDIA_API_KEY: ${NVIDIA_API_KEY}
       LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY}
       DATABASE_URL: postgresql://litellm:litellm_local@127.0.0.1:5500/litellm
       STORE_MODEL_IN_DB: "True"     # 允許 Admin UI 在 DB 加 model

--- a/litellm-config.yaml
+++ b/litellm-config.yaml
@@ -23,6 +23,32 @@ model_list:
       model: openai/gpt-4o-mini
       api_key: os.environ/OPENAI_API_KEY
 
+  # ===== NVIDIA NIM 免費 endpoint（多模型對照用）=====
+  - model_name: nvidia-llama
+    litellm_params:
+      model: nvidia_nim/meta/llama-3.1-70b-instruct
+      api_key: os.environ/NVIDIA_API_KEY
+
+  - model_name: nvidia-deepseek
+    litellm_params:
+      model: nvidia_nim/deepseek-ai/deepseek-v4-flash
+      api_key: os.environ/NVIDIA_API_KEY
+
+  - model_name: nvidia-qwen
+    litellm_params:
+      model: nvidia_nim/qwen/qwen3-next-80b-a3b-instruct
+      api_key: os.environ/NVIDIA_API_KEY
+
+  - model_name: nvidia-minimax
+    litellm_params:
+      model: nvidia_nim/minimaxai/minimax-m2.7
+      api_key: os.environ/NVIDIA_API_KEY
+
+  - model_name: nvidia-glm
+    litellm_params:
+      model: nvidia_nim/z-ai/glm-5.1
+      api_key: os.environ/NVIDIA_API_KEY
+
 router_settings:
   fallbacks:
     - local-cheap: ["cloud-fast"]


### PR DESCRIPTION
三個小變動一起 commit。

## NVIDIA NIM 整合

config 多 5 個 alias、env 補 `NVIDIA_API_KEY`、docker-compose 傳給 LiteLLM。
hello_world 動態抓 `/v1/models` 自動顯示，**ai-eva code 完全不用改**就多 5 條對照。

## hello_world 401 bug fix

M2.5 之後 `/v1/models` 也需 master key auth；hello_world 漏帶 Authorization
header 導致前端看到「拿不到 model 清單」。補 `LITELLM_API_KEY` 即解。

## LINE message event 也存 userId

之前只有 follow event 寫 `line_users` 表，使用者若在 webhook 上線前加好友
就抓不到 userId、push 不到。改成 message event 也 upsert，確保活躍使用者
都被記錄。

🤖 Generated with [Claude Code](https://claude.com/claude-code)