### PR TITLE
feat: M4 — Pi5 cron + RabbitMQ → LINE push

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,15 @@ LITELLM_LINE_KEY=
 # 配額：40 RPM；不穩、隨時可能變動，只用在 hello_world 對照
 NVIDIA_API_KEY=
 
+# ----- RabbitMQ (M4 cron push) -----
+# 產法：openssl rand -hex 16
+# ai-eva 容器在同個 docker network，用 rabbitmq:5672；
+# 外部 worker（Pi5 cron）走 Tailscale IP:5672 / :5673
+RABBITMQ_USER=evapush
+RABBITMQ_PASS=
+RABBITMQ_URL=amqp://evapush:PASS@rabbitmq:5672/
+RABBITMQ_QUEUE=line-push
+
 # ----- LINE Bot (M3) -----
 # LINE Developers Console → Messaging API channel
 # 空值 → /webhook/line 端點回 503，不啟用

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from app.apps._registry import chainlit_commands, default_app, discover, get_by_
 from app.core.storage import LocalStorageClient
 from app.settings import ROOT
 from app.surfaces import line as line_surface  # 註冊 /webhook/line route
+from app.surfaces import queue_consumer  # RabbitMQ consumer 給 M4 cron push 用
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +41,9 @@ try:
 except RuntimeError:
     # 沒 loop 就同步跑一次（import 階段）
     asyncio.run(line_surface.ensure_line_table())
+
+# 啟 RabbitMQ consumer（如果 .env 有設 RABBITMQ_URL）
+queue_consumer.start_in_background()
 
 
 async def _register_commands():

--- a/app/surfaces/queue_consumer.py
+++ b/app/surfaces/queue_consumer.py
@@ -1,0 +1,78 @@
+"""RabbitMQ consumer — 訂閱 line-push queue → push 給 LINE user。
+
+訊息格式（producer 必須遵守）：
+    {
+        "user_id": "U...",
+        "text": "要推播的內容",
+        "source": "pi5-eva-daily"     # 可選，給 log 用
+    }
+
+啟動方式：Chainlit 啟動時 fire-and-forget asyncio task（main.py 內 import 即註冊）。
+"""
+import asyncio
+import json
+import logging
+import os
+
+import aio_pika
+
+from app.surfaces.line import push_to_user
+
+logger = logging.getLogger(__name__)
+
+_RABBITMQ_URL = os.getenv("RABBITMQ_URL", "")
+_QUEUE = os.getenv("RABBITMQ_QUEUE", "line-push")
+
+
+async def _process_message(msg: aio_pika.IncomingMessage) -> None:
+    async with msg.process():   # auto-ack on success, requeue on exception
+        try:
+            payload = json.loads(msg.body)
+        except json.JSONDecodeError:
+            logger.error("queue payload not JSON: %r", msg.body[:200])
+            return
+
+        user_id = payload.get("user_id")
+        text = payload.get("text")
+        source = payload.get("source", "unknown")
+        if not user_id or not text:
+            logger.error("queue payload missing user_id/text: %s", payload)
+            return
+
+        logger.info("push (src=%s) to %s: %r", source, user_id, text[:80])
+        ok = await push_to_user(user_id, text)
+        if not ok:
+            logger.warning("push_to_user returned False (user_id=%s)", user_id)
+
+
+async def _consume_loop() -> None:
+    if not _RABBITMQ_URL:
+        logger.warning("RABBITMQ_URL not set; queue consumer disabled")
+        return
+
+    while True:
+        try:
+            logger.info("connecting RabbitMQ at %s", _RABBITMQ_URL.split("@")[-1])
+            conn = await aio_pika.connect_robust(_RABBITMQ_URL)
+            async with conn:
+                channel = await conn.channel()
+                await channel.set_qos(prefetch_count=10)
+                queue = await channel.declare_queue(_QUEUE, durable=True)
+                logger.info("listening on queue=%s", _QUEUE)
+                await queue.consume(_process_message)
+                # idle forever — connect_robust 會自己處理斷線重連
+                await asyncio.Future()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.exception("queue consumer crashed; retry in 10s: %s", e)
+            await asyncio.sleep(10)
+
+
+def start_in_background() -> asyncio.Task | None:
+    """Chainlit 沒有 on_app_startup decorator，main.py 直接 import + 呼叫這個。"""
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        return None
+    return loop.create_task(_consume_loop(), name="rabbitmq-consumer")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
         condition: service_healthy
       litellm:
         condition: service_started
+      rabbitmq:
+        condition: service_healthy
     env_file:
       - .env
     ports:
@@ -76,6 +78,27 @@ services:
       - ./litellm-config.yaml:/app/config.yaml:ro
     network_mode: host    # 為了能直接打 Pi5 Tailscale IP (100.74.6.41)
 
+  rabbitmq:
+    image: rabbitmq:3.13-management-alpine
+    container_name: ai-eva-rabbitmq
+    restart: unless-stopped
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASS}
+    volumes:
+      - ai_eva_rabbitmq:/var/lib/rabbitmq
+    ports:
+      - "5672:5672"     # AMQP
+      - "15672:15672"   # Management UI
+    # 不用 host network — 預設 bridge + ports 即可（Tailscale 從 Pi5 連 cms-server
+    # 的 Tailscale IP 100.66.105.30:5672 就會走 host port forwarding 進來）
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+
 volumes:
   ai_eva_pgdata:
   ai_eva_litellm_pgdata:
+  ai_eva_rabbitmq:

--- a/docs/m4-cron-push.md
+++ b/docs/m4-cron-push.md
@@ -1,0 +1,107 @@
+# M4 — Pi5 cron + RabbitMQ → LINE push
+
+> 第一條主動推播鏈路：Pi5 每天 09:00 跑 Qwen 寫早安 → publish 到 RabbitMQ → ai-eva consumer → LINE push 給使用者。
+> Roadmap [#8](https://github.com/towNingtek/ai-eva/issues/8) M4。
+
+## 拓樸
+
+```
+[Pi5（家裡）]                                        [cms-server（GCP）]
+ cron 09:00 daily                                    
+   ↓                                                 
+ /home/yillkid/eva-worker/eva_daily.py               
+   ├─ load env (.env in same dir)                    
+   ├─ qwen_chat() → 本機 Ollama Qwen 2.5:3b          
+   │    "請寫早安鼓勵..."                            
+   ├─ pika.BlockingConnection                        
+   │    via Tailscale 100.66.105.30:5673             
+   └─ basic_publish queue=line-push                   ┌────────────────────────────┐
+                                                  ────│ ai-eva-rabbitmq-stable     │
+                                                      │ container :5673:5672       │
+                                                      │ user evapush               │
+                                                      │ queue line-push (durable)  │
+                                                      └────┬───────────────────────┘
+                                                           │
+                                                           ↓ aio-pika subscribe
+                                                      ┌────────────────────────────┐
+                                                      │ ai-eva-stable container    │
+                                                      │  app/surfaces/queue_consumer.py
+                                                      │  ↓ 解析 {user_id, text}    │
+                                                      │  ↓ push_to_user(...)       │
+                                                      └────┬───────────────────────┘
+                                                           ↓ LINE Messaging API
+                                                      [使用者手機 LINE]
+```
+
+## 元件清單
+
+| 位置 | 元件 | 角色 |
+|---|---|---|
+| Pi5 | `~/eva-worker/eva_daily.py` | cron 觸發的 producer |
+| Pi5 | `~/eva-worker/.env` | RABBITMQ_URL / PUSH_USER_ID（不進 git） |
+| Pi5 | `crontab` | `0 9 * * * /usr/bin/python3 ~/eva-worker/eva_daily.py` |
+| cms-server beta | `ai-eva-rabbitmq` (:5672 / :15672) | beta 環境 RabbitMQ |
+| cms-server stable | `ai-eva-rabbitmq-stable` (:5673 / :15673) | **prod**，cron 推這 |
+| ai-eva 兩邊 | `app/surfaces/queue_consumer.py` | aio-pika consumer，啟動時 fire-and-forget |
+
+## env vars
+
+### Pi5 `~/eva-worker/.env`
+```bash
+RABBITMQ_URL=amqp://evapush:<STABLE_PASS>@100.66.105.30:5673/
+RABBITMQ_QUEUE=line-push
+PUSH_USER_ID=U....               # 你的 LINE userId
+```
+
+### ai-eva container（兩個環境各設）
+```bash
+RABBITMQ_USER=evapush
+RABBITMQ_PASS=<env-specific>
+RABBITMQ_URL=amqp://evapush:<env-specific>@rabbitmq:5672/  # 容器內網
+RABBITMQ_QUEUE=line-push
+```
+
+## 為什麼 Pi5 看到 cms-server 是 :5673（而不是 :5672）
+
+- Beta rabbitmq 占了 cms-server host 的 :5672
+- Stable override 把它擠到 :5673
+- 兩個都對 Tailscale 開放
+- Cron worker 推 prod（stable）→ 5673
+
+如果之後要在 beta 測 cron：改 Pi5 `.env` 把 URL port 改成 5672 + 用 beta 的 password。
+
+## 手動觸發測試
+
+```bash
+# Pi5 上
+python3 ~/eva-worker/eva_daily.py
+```
+
+預期：
+1. 印 pika 連線成功
+2. 印 "published N chars to queue=line-push"
+3. **2-3 秒內你 LINE 收到 Qwen 寫的早安**
+
+如果 LINE 沒收到：
+- 看 `ai-eva-stable` 容器 log（`docker logs ai-eva-stable | grep queue`）— 有沒有看到「push (src=pi5-eva-daily)」
+- 看 RabbitMQ 管理頁 http://localhost:15673（admin / evapush + master pass）— queue depth 是不是堆積
+- 看 LINE webhook log — push API 是不是 200
+
+## 為什麼 RabbitMQ 不用 host network
+
+- LiteLLM 要打 Pi5 Tailscale IP 100.74.6.41 → 需要 host network
+- RabbitMQ 反過來：Pi5 打 cms-server，cms-server 用 ports forwarding 暴露 5673/15673
+- bridge mode + ports 即可，比 host 乾淨
+
+## 後續方向
+
+- **M3 session 進來後**：cron push 帶 session_id metadata、push 完不會被當「對話的一部分」誤吃進 context
+- **多個 cron 任務**：在 Pi5 同 directory 加 `eva_weekly.py` / `eva_alert.py`，各自 crontab 行
+- **多個 user**：cron script 改成查 PG `line_users` 表所有 active user、逐個 push
+- **失敗重試 / dead letter**：RabbitMQ 預設沒 DLQ，要加得寫 retry policy
+- **看 cost**：LiteLLM Admin UI 看每個 virtual key 累計 — 但 cron 走 Pi5 不耗 LiteLLM 預算
+
+## 已踩過的坑
+
+- **Stable 的 docker-compose.yml 跟 beta 同步**：直接 `cp beta → stable`（git 同步前的人工搬）
+- **第一次 RabbitMQ 拉 image 慢**：~10 秒，consumer 啟動會 retry 重連、不要慌

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ asyncpg>=0.29,<1.0
 greenlet>=3,<4
 httpx>=0.27,<1.0
 ddgs>=6,<10
+aio-pika>=9,<10


### PR DESCRIPTION
Roadmap [#8](https://github.com/towNingtek/ai-eva/issues/8) M4 closes.

第一條主動推播鏈路：Pi5 每天 09:00 跑本機 Qwen 寫早安，經 RabbitMQ → ai-eva consumer → LINE push 到使用者。

## 已實測

| 環節 | 結果 |
|---|---|
| Pi5 → Tailscale → cms-server :5673 | ✓ |
| RabbitMQ stable queue line-push | ✓ |
| ai-eva-stable consumer 收訊 | ✓ |
| LINE push API 200 OK | ✓ |
| 使用者手機 LINE 收到「☀️ ...早安」 | ✓ |

## 已設 crontab

Pi5: `0 9 * * * /usr/bin/python3 /home/yillkid/eva-worker/eva_daily.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)