### PR TITLE
feat: Phase 1 Admin Hub — SSO 後台收尾 M2.5/M3/M4

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 >
 > 中長期演化為個人 / 內部用的 **本地 + 雲端混合 LLM 場域**，搭配 Pi5 hub、LINE bot 推播、模擬感測器，做為日常 AI 工具的「沙盒」。
 
-[相關討論](https://github.com/town-intelligent/swarm/issues/151) ・ [線上 stable](https://eva.4impact.cc)
+[相關討論](https://github.com/town-intelligent/swarm/issues/151) ・ [線上 stable](https://eva.4impact.cc) ・ [Admin Hub](https://eva-admin.4impact.cc)（SSO 後台）
 
 ---
 
@@ -207,11 +207,12 @@ docker compose -p ai-eva-stable up -d --no-deps ai-eva
 |---|---|---|---|
 | **M1** | **Pi5 Hub 設置** | Pi5 + Ollama + Qwen 2.5:3b-q4 + Cloudflare Zero Trust SSH | ✅ [#9](https://github.com/towNingtek/ai-eva/issues/9) |
 | **M2** | **LiteLLM 接通** | LiteLLM proxy + Tailscale 連 Pi5；ai-eva 全走 LiteLLM；hello_world 改成多模型對照 demo | ✅ [#12](https://github.com/towNingtek/ai-eva/issues/12) |
-| M2.5 | *(可選)* LiteLLM 進階運維 | virtual keys / 預算 / multi-key 負載均衡 / cost dashboard | 視 M3 需求啟動 |
-| M3 | **LINE Bot Adapter** | LINE Messaging API webhook → Chainlit FastAPI app → 同一個 dispatch | |
-| M4 | **第一條被動推播 graph** | Pi5 cron + RabbitMQ → LINE push（daily summary） | |
+| **M2.5** | **LiteLLM 進階運維** | virtual keys / 預算 / NVIDIA NIM 多模型 / Admin UI 對外（`eva-litellm.4impact.cc`） | ✅ |
+| M3 | **LINE Bot Adapter** | LINE Messaging API webhook → Chainlit FastAPI app → 同一個 dispatch | ✅ |
+| M4 | **第一條被動推播 graph** | Pi5 cron + RabbitMQ → LINE push（daily summary，9 點 Qwen 寫早安） | ✅ |
+| **Phase 1** | **Admin Hub** | Cloudflare Tunnel + Access SSO 集中：landing / RabbitMQ Mgmt / LiteLLM Admin / ai-eva（[docs](docs/admin-hub.md)） | ✅ |
 | M5 | **模擬感測 + 異常預警** | LightGBM 預測（參考 [Pi5 IoT-LLM 文章](https://cheng-min-i-taiwan.blogspot.com/2026/05/usr-5-iot-llm.html)）→ Qwen 解讀 → LINE push | |
-| M6 | **Web Admin UI**（甜點，最後做） | *可能大幅縮減* — LiteLLM 自帶 key/cost/log UI；剩下只有 ai-eva 自家「app 啟用 / 使用者權限」 | |
+| Phase 2 | **自家管理 UI** | 等真有多 user 才動；ai-eva 自家「app 啟用 / 使用者權限」 | |
 
 每個里程碑對應一個 GitHub milestone，下面再切細 issue。詳見 [roadmap tracking issue #8](https://github.com/towNingtek/ai-eva/issues/8)。
 

--- a/docs/admin-hub.md
+++ b/docs/admin-hub.md
@@ -1,0 +1,159 @@
+# Eva Admin Hub（運維入口）
+
+> 把 RabbitMQ / LiteLLM 管理 UI、ai-eva 站點等所有運維 surface 收進一個 SSO 後台、避免每次都得 SSH tunnel。
+
+## 拓樸
+
+```
+你瀏覽器 (任何地方)
+   ↓
+Cloudflare Access SSO（OTP 或 Google login，policy = me 白名單）
+   ↓
+Cloudflare Tunnel "tplanet-4impact"
+   ↓
+       eva-admin.4impact.cc      → nginx → /var/www/eva-admin (landing)
+       eva-rabbitmq.4impact.cc   → :15673 (stable RabbitMQ Mgmt)
+       eva-litellm.4impact.cc    → :4001  (stable LiteLLM Admin UI)
+```
+
+Beta 環境（:5672 RabbitMQ / :4000 LiteLLM）刻意**不對外**、用 SSH tunnel 進，避免 dev 場域被誤用。
+
+## 五個 surface 對應 URL
+
+| URL | 後端 | 認證 |
+|---|---|---|
+| `https://eva-admin.4impact.cc` | nginx 靜態 landing page | Cloudflare Access |
+| `https://eva-rabbitmq.4impact.cc` | `localhost:15673` RabbitMQ Mgmt UI | CF Access + RabbitMQ user/pass |
+| `https://eva-litellm.4impact.cc/ui` | `localhost:4001/ui` LiteLLM Admin UI | CF Access + master key |
+| `https://eva.4impact.cc` | `localhost:7861` ai-eva stable（既有） | Chainlit password auth |
+| `https://beta-eva.4impact.cc` | `localhost:7860` ai-eva beta（既有） | Chainlit password auth |
+
+## 部署清單（給未來自己 / 從零重建）
+
+### 1. DNS
+
+3 個 CNAME 指 tunnel（proxied=true、TTL auto）：
+
+| name | target |
+|---|---|
+| `eva-admin` | `c962e3fc-1501-414a-9f5d-76efa549072a.cfargotunnel.com` |
+| `eva-rabbitmq` | 同上 |
+| `eva-litellm` | 同上 |
+
+用 Cloudflare DNS API（需 Zone:DNS:Edit 權限）：
+
+```bash
+CF=<api_token>
+ZONE=1394ee0496f8ebaa30ba9a33155809d5    # 4impact.cc
+TARGET="c962e3fc-1501-414a-9f5d-76efa549072a.cfargotunnel.com"
+for name in eva-admin eva-rabbitmq eva-litellm; do
+  curl -s -X POST -H "Authorization: Bearer $CF" -H "Content-Type: application/json" \
+    "https://api.cloudflare.com/client/v4/zones/$ZONE/dns_records" \
+    -d "{\"type\":\"CNAME\",\"name\":\"$name\",\"content\":\"$TARGET\",\"proxied\":true,\"ttl\":1}"
+done
+```
+
+### 2. Cloudflare Tunnel ingress
+
+加進 `/etc/cloudflared/config.yml`（在 `# AI Eva BETA` 上方插入）：
+
+```yaml
+# AI Eva Admin Hub (Phase 1)
+- hostname: eva-admin.4impact.cc
+  service: http://localhost:80
+- hostname: eva-rabbitmq.4impact.cc
+  service: http://localhost:15673
+- hostname: eva-litellm.4impact.cc
+  service: http://localhost:4001
+```
+
+完整片段見 `ops/eva-admin/cloudflared-ingress.snippet.yaml`。
+
+```bash
+sudo systemctl restart cloudflared
+```
+
+### 3. Nginx landing page
+
+```bash
+sudo mkdir -p /var/www/eva-admin
+sudo cp ops/eva-admin/index.html /var/www/eva-admin/
+sudo cp ops/eva-admin/eva-admin.4impact.cc.nginx.conf /etc/nginx/sites-available/eva-admin.4impact.cc
+sudo ln -sf /etc/nginx/sites-available/eva-admin.4impact.cc /etc/nginx/sites-enabled/eva-admin.4impact.cc
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+### 4. Cloudflare Access Application
+
+用 API（需 Account:Cloudflare One: Apps:Edit + Access:IdP:Edit 權限）：
+
+```bash
+CF=<api_token>
+AID=58fc30c9c529515be7c65b903d70fbc3   # Yillkid@gmail.com's Account
+
+# 建 application
+curl -s -X POST -H "Authorization: Bearer $CF" -H "Content-Type: application/json" \
+  "https://api.cloudflare.com/client/v4/accounts/$AID/access/apps" \
+  -d '{
+    "name": "Eva Admin Hub",
+    "type": "self_hosted",
+    "domain": "eva-admin.4impact.cc",
+    "self_hosted_domains": [
+      "eva-admin.4impact.cc",
+      "eva-rabbitmq.4impact.cc",
+      "eva-litellm.4impact.cc"
+    ],
+    "session_duration": "24h"
+  }'
+# 拿回的 id → APP_ID
+
+# 建 policy（白名單三個 email）
+curl -s -X POST -H "Authorization: Bearer $CF" -H "Content-Type: application/json" \
+  "https://api.cloudflare.com/client/v4/accounts/$AID/access/apps/$APP_ID/policies" \
+  -d '{
+    "name": "me",
+    "decision": "allow",
+    "include": [
+      {"email": {"email": "yillkid@gmail.com"}},
+      {"email": {"email": "townintelligent@gmail.com"}},
+      {"email": {"email": "jyun-yu@4impact.cc"}}
+    ]
+  }'
+```
+
+或在 UI 操作（一次性 token 用完就撤銷）：
+- https://one.dash.cloudflare.com/58fc30c9c529515be7c65b903d70fbc3/access/apps
+- Add an application → Self-hosted → 三個 hostname 一次加 → Policy 三個 email
+
+### 5. 驗證
+
+| 測試 | 預期 |
+|---|---|
+| `curl https://eva-admin.4impact.cc` | Cloudflare Access 登入頁（HTML 含 `cloudflare access`） |
+| 瀏覽器登入後開 `eva-admin.4impact.cc` | 看到黑底 Eva Admin Hub landing |
+| 點 LiteLLM 連結 | 跳到 `eva-litellm.4impact.cc/ui` 看到 LiteLLM 登入 |
+| 點 RabbitMQ 連結 | 跳到 `eva-rabbitmq.4impact.cc` 看到 RabbitMQ Mgmt 登入 |
+
+## 已踩過的坑
+
+- **OTP 不到 Gmail**：Cloudflare Access 預設只給 onetimepin IdP，OTP 容易被 Gmail spam 過濾。**用公司 email**（`jyun-yu@4impact.cc`）登入比較穩；長期想無痛 SSO 要在 Cloudflare 額外設 Google IdP（要 GCP OAuth client）
+- **Path-based proxy 跟 subdomain 比**：RabbitMQ + LiteLLM hardcoded asset path、用 subdomain 直 proxy 最穩、path 模式會 debug 到死
+- **DNS:Edit / Access:Apps:Edit 是兩種 token 權限**：要分開檢查、別用 Global API Key（高風險）
+- **Beta admin 不對外**：避免開發環境 cost / queue 被外界看到、開發者自己 SSH tunnel 即可
+
+## Beta 環境 admin（SSH tunnel 模式）
+
+```bash
+# Mac 上跑
+ssh -L 4000:localhost:4000 -L 15672:localhost:15672 gcp
+
+# 瀏覽器
+http://localhost:4000/ui    # Beta LiteLLM
+http://localhost:15672      # Beta RabbitMQ Mgmt
+```
+
+## 後續
+
+- **Phase 2**：自家「使用者 / app 管理 UI」— 等真有多 user 才動
+- **Google SSO IdP**：GCP Console 建 OAuth client、Cloudflare Access 加 IdP、policy 加上 Google login
+- **更多 surface**：之後加 pgAdmin / Grafana 等就照 step 1-4 流程加新 hostname

--- a/ops/eva-admin/cloudflared-ingress.snippet.yaml
+++ b/ops/eva-admin/cloudflared-ingress.snippet.yaml
@@ -1,0 +1,13 @@
+    service: http://localhost:8001
+  # AI Eva Admin Hub (Phase 1)
+  - hostname: eva-admin.4impact.cc
+    service: http://localhost:80
+  - hostname: eva-rabbitmq.4impact.cc
+    service: http://localhost:15673
+  - hostname: eva-litellm.4impact.cc
+    service: http://localhost:4001
+
+  # AI Eva BETA (Chainlit + LangGraph + RAG)
+  - hostname: beta-eva.4impact.cc
+    service: http://localhost:7860
+  - hostname: aa-test.4impact.cc

--- a/ops/eva-admin/eva-admin.4impact.cc.nginx.conf
+++ b/ops/eva-admin/eva-admin.4impact.cc.nginx.conf
@@ -1,0 +1,14 @@
+# Eva Admin Hub landing — 由 Cloudflare Tunnel 從 eva-admin.4impact.cc 進來
+# 已在 Cloudflare Access 後面（user 必須 SSO 才看得到）
+server {
+    listen 80;
+    server_name eva-admin.4impact.cc;
+    root /var/www/eva-admin;
+    index index.html;
+    access_log /var/log/nginx/eva-admin.access.log;
+    error_log /var/log/nginx/eva-admin.error.log;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}

--- a/ops/eva-admin/index.html
+++ b/ops/eva-admin/index.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="zh-TW">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Eva Admin Hub</title>
+  <style>
+    :root{
+      --bg:#0f1419;--card:#1c2230;--card-hover:#252e42;--fg:#e8eef7;
+      --muted:#8b96a8;--accent:#6366f1;--border:#2a3142;--warn:#facc15;
+    }
+    *{box-sizing:border-box}
+    body{font:16px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans TC",Roboto,sans-serif;
+         margin:0;background:var(--bg);color:var(--fg);min-height:100vh}
+    .wrap{max-width:1100px;margin:0 auto;padding:48px 24px}
+    header{margin-bottom:32px}
+    h1{margin:0 0 8px;font-size:28px}
+    .sub{color:var(--muted);font-size:14px}
+    .sec-title{font-size:13px;color:var(--muted);text-transform:uppercase;
+               letter-spacing:.08em;margin:32px 0 12px}
+    .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:14px}
+    a.card{display:flex;flex-direction:column;gap:6px;
+           padding:18px 20px;border-radius:12px;background:var(--card);
+           border:1px solid var(--border);color:var(--fg);text-decoration:none;
+           transition:background .15s,border-color .15s,transform .15s}
+    a.card:hover{background:var(--card-hover);border-color:var(--accent);transform:translateY(-1px)}
+    .card .title{display:flex;align-items:center;gap:10px;font-weight:600;font-size:16px}
+    .card .icon{font-size:22px}
+    .card .desc{color:var(--muted);font-size:13px;margin-top:2px}
+    .card .badge{display:inline-block;padding:2px 8px;border-radius:999px;
+                 font-size:11px;font-weight:600;align-self:flex-start;margin-top:8px}
+    .badge.stable{background:rgba(34,197,94,.15);color:#22c55e}
+    .badge.beta{background:rgba(250,204,21,.15);color:var(--warn)}
+    .badge.tool{background:rgba(99,102,241,.15);color:var(--accent)}
+    pre{background:#0a0e14;border:1px solid var(--border);border-radius:8px;
+        padding:14px;overflow-x:auto;font-size:13px;color:#a5b1c5}
+    code{font-family:"SF Mono",Menlo,Consolas,monospace}
+    footer{margin-top:48px;color:var(--muted);font-size:12px;text-align:center}
+    footer a{color:var(--muted)}
+  </style>
+</head>
+<body>
+<div class="wrap">
+
+<header>
+  <h1>🎛 Eva Admin Hub</h1>
+  <div class="sub">運維工具集中入口 — 走 Cloudflare Tunnel + Access SSO 保護</div>
+</header>
+
+<div class="sec-title">使用者站台</div>
+<div class="grid">
+  <a class="card" href="https://eva.4impact.cc">
+    <div class="title"><span class="icon">💬</span>ai-eva</div>
+    <div class="desc">Chainlit web chat，使用者用</div>
+    <span class="badge stable">STABLE :7861</span>
+  </a>
+  <a class="card" href="https://beta-eva.4impact.cc">
+    <div class="title"><span class="icon">💬</span>ai-eva</div>
+    <div class="desc">開發環境，僅內部測試用</div>
+    <span class="badge beta">BETA :7860</span>
+  </a>
+</div>
+
+<div class="sec-title">LLM 閘道 (LiteLLM)</div>
+<div class="grid">
+  <a class="card" href="https://eva-litellm.4impact.cc/ui">
+    <div class="title"><span class="icon">🤖</span>LiteLLM Admin UI</div>
+    <div class="desc">virtual keys / spend tracking / models / logs</div>
+    <span class="badge stable">STABLE :4001</span>
+  </a>
+</div>
+
+<div class="sec-title">訊息佇列 (RabbitMQ)</div>
+<div class="grid">
+  <a class="card" href="https://eva-rabbitmq.4impact.cc">
+    <div class="title"><span class="icon">🐰</span>RabbitMQ Mgmt UI</div>
+    <div class="desc">看 line-push queue、訊息積壓、消費者連線</div>
+    <span class="badge stable">STABLE :15673</span>
+  </a>
+</div>
+
+<div class="sec-title">Beta 環境（SSH tunnel 進）</div>
+<div class="grid">
+  <a class="card" href="#beta-tunnel">
+    <div class="title"><span class="icon">🔌</span>看 beta admin UIs</div>
+    <div class="desc">beta 沒對外、需要 SSH tunnel 從 mac 進</div>
+    <span class="badge tool">Mac only</span>
+  </a>
+</div>
+<pre id="beta-tunnel"># Mac 終端機跑這個（保持開著）：
+ssh -L 4000:localhost:4000 -L 15672:localhost:15672 gcp
+
+# 然後本機開：
+#   http://localhost:4000/ui    ← Beta LiteLLM
+#   http://localhost:15672      ← Beta RabbitMQ</pre>
+
+<div class="sec-title">Docs / 程式碼</div>
+<div class="grid">
+  <a class="card" href="https://github.com/towNingtek/ai-eva">
+    <div class="title"><span class="icon">📂</span>GitHub Repo</div>
+    <div class="desc">towNingtek/ai-eva</div>
+  </a>
+  <a class="card" href="https://github.com/towNingtek/ai-eva/tree/main/docs">
+    <div class="title"><span class="icon">📘</span>Docs 目錄</div>
+    <div class="desc">litellm-setup / pi5-setup / line-bot / m4-cron / litellm-admin</div>
+  </a>
+  <a class="card" href="https://github.com/towNingtek/ai-eva/issues/8">
+    <div class="title"><span class="icon">🗺</span>Roadmap (#8)</div>
+    <div class="desc">里程碑 + 架構決策</div>
+  </a>
+</div>
+
+<footer>
+  Eva Admin Hub · Phase 1 ·
+  <a href="https://github.com/towNingtek/ai-eva">github.com/towNingtek/ai-eva</a>
+</footer>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

把 ai-eva 三個運維 surface 從 SSH tunnel 升級成 SSO 後台：

- \`eva-admin.4impact.cc\` — nginx landing page（卡片導覽）
- \`eva-rabbitmq.4impact.cc\` — stable RabbitMQ Mgmt UI (:15673)
- \`eva-litellm.4impact.cc\` — stable LiteLLM Admin UI (:4001)

走 Cloudflare Tunnel + Cloudflare Access SSO（email 白名單 policy），避免每次都得 \`ssh -L\` 進 admin UI。

Beta 環境的 admin (:5672 / :4000) 刻意**不對外**、僅 SSH tunnel 進，避免 dev cost / queue 被誤用。

## 變更

- \`docs/admin-hub.md\` — 完整重建文件（DNS / Tunnel ingress / nginx / Access app + policy / 驗證 / 已踩過的坑）
- \`ops/eva-admin/\` — 系統設定備份
  - \`index.html\` — landing page（黑底卡片）
  - \`eva-admin.4impact.cc.nginx.conf\` — nginx server block
  - \`cloudflared-ingress.snippet.yaml\` — tunnel ingress entries
- README — 加 Admin Hub link + roadmap 表標記 M2.5/M3/M4/Phase 1 ✅

## Test plan

- [x] \`https://eva-admin.4impact.cc\` 走 Cloudflare Access OTP / Google login
- [x] 登入後看到 landing page，點 RabbitMQ / LiteLLM 連結都通
- [x] beta 環境 admin 維持只有 SSH tunnel 可進
- [x] eva.4impact.cc / beta-eva.4impact.cc 既有 surface 不受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)