### PR TITLE
feat: LINE session memory — 對話式記憶 + 30min 逾時自動結束

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -34,13 +34,20 @@ if ADMIN_PASS:
 
 discover()
 
-# 啟動時建 line_users 表（給 LINE follow event 紀錄用）。Chainlit 沒 on_app_startup
-# decorator，這裡直接用 asyncio fire-and-forget。
+# 啟動時建 line_users + line_sessions/line_session_messages 表（給 LINE 用）。
+# Chainlit 沒 on_app_startup decorator，這裡直接用 asyncio fire-and-forget。
+from app.surfaces import line_session  # noqa: E402
+
+
+async def _init_line_tables():
+    await line_surface.ensure_line_table()
+    await line_session.ensure_session_tables()
+
+
 try:
-    asyncio.get_event_loop().create_task(line_surface.ensure_line_table())
+    asyncio.get_event_loop().create_task(_init_line_tables())
 except RuntimeError:
-    # 沒 loop 就同步跑一次（import 階段）
-    asyncio.run(line_surface.ensure_line_table())
+    asyncio.run(_init_line_tables())
 
 # 啟 RabbitMQ consumer（如果 .env 有設 RABBITMQ_URL）
 queue_consumer.start_in_background()

--- a/app/surfaces/line.py
+++ b/app/surfaces/line.py
@@ -1,13 +1,15 @@
-"""LINE Messaging API adapter — M3。
+"""LINE Messaging API adapter。
 
-掛在 Chainlit 的 FastAPI app 上的 `/webhook/line`：
-- 收 LINE 事件 → 簽章驗證 → 處理 message / follow / unfollow
-- message → LiteLLM (走 LITELLM_LINE_KEY 獨立 virtual key) → reply
-- follow → 把 userId 存進 PG `line_users`（給 M4 push 用）
+掛在 Chainlit 的 FastAPI app 上：
+- `/webhook/line`        收 LINE 事件 → 簽章驗證 → message / follow / unfollow
+  - message text → session.chat() (with memory) → reply
+  - 結束關鍵字 → end_session + reply 告別
+- `/tasks/scan-timeouts` 給 sidecar curl 每 60s 戳，掃 idle 過久 session、push 告別
+- follow → 把 userId 存進 PG `line_users`（給 push 用）
 
-push helper `push_to_user()` 預先寫好，等 M4 cron worker 來呼叫。
+session 記憶實作在 line_session.py（兩張表 line_sessions / line_session_messages）。
+push helper `push_to_user()` 給 M4 cron worker / scan_timeouts 用。
 """
-import asyncio
 import base64
 import hashlib
 import hmac
@@ -21,17 +23,17 @@ import httpx
 from chainlit.server import app as fastapi_app
 from fastapi import HTTPException, Request
 
-from app.core.llm import make_llm
+from app.surfaces import line_session
 from app.settings import (
     LINE_CHANNEL_ACCESS_TOKEN,
     LINE_CHANNEL_SECRET,
-    LITELLM_LINE_KEY,
 )
 
 logger = logging.getLogger(__name__)
 
 _LINE_API = "https://api.line.me/v2/bot"
 _DATABASE_URL = os.getenv("DATABASE_URL", "")
+_SESSION_SCAN_TOKEN = os.getenv("SESSION_SCAN_TOKEN", "").strip()
 
 
 def _pg_url() -> str:
@@ -132,11 +134,23 @@ def _verify_signature(body: bytes, signature: str) -> bool:
     return hmac.compare_digest(signature, expected)
 
 
-def _llm_answer_sync(text: str) -> str:
-    return make_llm(
-        api_key=LITELLM_LINE_KEY or None,  # 帳單算進 line-bot virtual key
-        streaming=False,
-    ).invoke(text).content
+@fastapi_app.post("/tasks/scan-timeouts")
+async def scan_timeouts_endpoint(req: Request):
+    """Sidecar 每 60s 來戳，掃 idle 過久的 session、push 告別訊息。
+
+    `X-Scan-Token` 要符合 SESSION_SCAN_TOKEN（沒設就完全擋掉、避免裸跑）。
+    """
+    if not _SESSION_SCAN_TOKEN:
+        raise HTTPException(503, "Session scanner not configured (SESSION_SCAN_TOKEN missing)")
+    if req.headers.get("x-scan-token", "") != _SESSION_SCAN_TOKEN:
+        raise HTTPException(403, "Invalid token")
+
+    timed_out = await line_session.scan_timeouts()
+    pushed = 0
+    for row in timed_out:
+        if await push_to_user(row["user_id"], line_session.GOODBYE_TIMEOUT):
+            pushed += 1
+    return {"ended": len(timed_out), "pushed": pushed}
 
 
 @fastapi_app.post("/webhook/line")
@@ -185,19 +199,21 @@ async def _handle_event(event: dict) -> None:
 
     text = (msg.get("text") or "").strip()
     reply_token = event.get("replyToken")
-    if not text or not reply_token:
+    if not text or not reply_token or not user_id:
         return
 
     logger.info("LINE message from %s: %r", user_id, text[:80])
 
     # 順手把 message sender 也 upsert 進 line_users（如果之前 follow 沒抓到）
-    if user_id:
-        await _save_follow(user_id)
+    await _save_follow(user_id)
 
-    try:
-        answer = (await asyncio.to_thread(_llm_answer_sync, text)).strip()
-    except Exception as e:
-        logger.exception("LLM call failed for LINE message")
-        answer = f"⚠️ 處理失敗，請稍後再試（{type(e).__name__}）"
+    # 結束關鍵字 → 收掉 active session、回告別訊息
+    if line_session.is_end_keyword(text):
+        sess = await line_session.get_active_session(user_id)
+        if sess is not None:
+            await line_session.end_session(sess["id"], "user")
+        await _line_reply(reply_token, line_session.GOODBYE_USER_INITIATED)
+        return
 
+    answer = await line_session.chat(user_id, text)
     await _line_reply(reply_token, answer)

--- a/app/surfaces/line_session.py
+++ b/app/surfaces/line_session.py
@@ -1,0 +1,227 @@
+"""LINE Bot 對話記憶（session memory）。
+
+從 4-learn/rag-kit/apps/huwei_landmarks (虎科大 ch5) 移植過來、改寫成：
+- 純 asyncpg（跟 line.py 的 line_users 表同風格）
+- LiteLLM via make_llm()（用 LITELLM_LINE_KEY 算帳）
+
+兩張表：
+  line_sessions          一筆 = 一段對話。ended_at IS NULL → active
+  line_session_messages  role=user/assistant、按 created_at 排序
+
+對外 5 個 function：
+- ensure_session_tables()        啟動建表
+- start_session(user_id)         開新 session（若有 active 先收掉）
+- end_session(session_id, reason)
+- chat(user_id, text)            收訊 → 拿/建 active session → LLM → 回覆字串
+- scan_timeouts(idle_minutes)    回傳逾時的 active session（給 /tasks 用）
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+import asyncpg
+
+from app.core.llm import make_llm
+from app.settings import LITELLM_LINE_KEY
+
+logger = logging.getLogger(__name__)
+
+_DATABASE_URL = os.getenv("DATABASE_URL", "")
+_CONTEXT_TURNS = int(os.getenv("SESSION_CONTEXT_TURNS", "12"))
+_TIMEOUT_MINUTES = int(os.getenv("SESSION_TIMEOUT_MINUTES", "30"))
+
+EVA_SYSTEM_PROMPT = """你是 Eva，使用者的個人 AI 助手。
+
+回答原則：
+- 簡短、口語、繁體中文（每則回覆 100 字內）
+- 不確定的事情誠實說「我不確定」、不要編造
+- 跟使用者像朋友聊天，不端架子
+- 你可以聊一般話題、知識問答、生活想法；不適合的請求（醫療診斷 / 法律意見）建議找專業
+"""
+
+
+def _pg_url() -> str:
+    return _DATABASE_URL.replace("postgresql+asyncpg://", "postgresql://")
+
+
+async def _connect() -> asyncpg.Connection:
+    return await asyncpg.connect(_pg_url())
+
+
+async def ensure_session_tables() -> None:
+    if not _DATABASE_URL:
+        logger.warning("DATABASE_URL not set; session memory disabled")
+        return
+    conn = await _connect()
+    try:
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS line_sessions (
+                id              BIGSERIAL PRIMARY KEY,
+                user_id         TEXT NOT NULL,
+                started_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                last_message_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                ended_at        TIMESTAMPTZ,
+                end_reason      TEXT,
+                summary         TEXT
+            );
+            CREATE INDEX IF NOT EXISTS ix_line_sessions_user_active
+                ON line_sessions (user_id, ended_at);
+
+            CREATE TABLE IF NOT EXISTS line_session_messages (
+                id          BIGSERIAL PRIMARY KEY,
+                session_id  BIGINT NOT NULL REFERENCES line_sessions(id) ON DELETE CASCADE,
+                role        TEXT NOT NULL,
+                content     TEXT NOT NULL,
+                created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            );
+            CREATE INDEX IF NOT EXISTS ix_line_session_messages_session
+                ON line_session_messages (session_id, created_at);
+            """
+        )
+    finally:
+        await conn.close()
+
+
+async def get_active_session(user_id: str) -> Optional[dict]:
+    if not _DATABASE_URL:
+        return None
+    conn = await _connect()
+    try:
+        row = await conn.fetchrow(
+            "SELECT id, user_id, started_at FROM line_sessions "
+            "WHERE user_id = $1 AND ended_at IS NULL "
+            "ORDER BY id DESC LIMIT 1",
+            user_id,
+        )
+        return dict(row) if row else None
+    finally:
+        await conn.close()
+
+
+async def start_session(user_id: str) -> dict:
+    conn = await _connect()
+    try:
+        await conn.execute(
+            "UPDATE line_sessions SET ended_at = NOW(), end_reason = 'replaced' "
+            "WHERE user_id = $1 AND ended_at IS NULL",
+            user_id,
+        )
+        row = await conn.fetchrow(
+            "INSERT INTO line_sessions (user_id) VALUES ($1) "
+            "RETURNING id, user_id, started_at",
+            user_id,
+        )
+        return dict(row)
+    finally:
+        await conn.close()
+
+
+async def end_session(session_id: int, reason: str) -> None:
+    conn = await _connect()
+    try:
+        await conn.execute(
+            "UPDATE line_sessions SET ended_at = NOW(), end_reason = $2 "
+            "WHERE id = $1 AND ended_at IS NULL",
+            session_id, reason,
+        )
+    finally:
+        await conn.close()
+
+
+async def _add_message(session_id: int, role: str, content: str) -> None:
+    conn = await _connect()
+    try:
+        await conn.execute(
+            "INSERT INTO line_session_messages (session_id, role, content) VALUES ($1, $2, $3)",
+            session_id, role, content,
+        )
+        await conn.execute(
+            "UPDATE line_sessions SET last_message_at = NOW() WHERE id = $1",
+            session_id,
+        )
+    finally:
+        await conn.close()
+
+
+async def _recent_messages(session_id: int, limit: int) -> list[dict]:
+    conn = await _connect()
+    try:
+        rows = await conn.fetch(
+            "SELECT role, content FROM line_session_messages "
+            "WHERE session_id = $1 ORDER BY id DESC LIMIT $2",
+            session_id, limit,
+        )
+        return list(reversed([dict(r) for r in rows]))
+    finally:
+        await conn.close()
+
+
+async def chat(user_id: str, user_text: str) -> str:
+    """收 user 一則文字 → 拿 active session（沒有就建）→ append → LLM → 回 reply。
+
+    結束關鍵字判斷在 caller (line.py)，這層只處理「一般對話」。
+    """
+    sess = await get_active_session(user_id) or await start_session(user_id)
+    sid = sess["id"]
+
+    await _add_message(sid, "user", user_text)
+    history = await _recent_messages(sid, _CONTEXT_TURNS)
+
+    messages = [{"role": "system", "content": EVA_SYSTEM_PROMPT}] + [
+        {"role": m["role"], "content": m["content"]} for m in history
+    ]
+
+    llm = make_llm(api_key=LITELLM_LINE_KEY or None, streaming=False)
+    try:
+        result = await llm.ainvoke(messages)
+        reply = (result.content or "").strip() or "（這次沒拿到回應，再試一次）"
+    except Exception as e:  # noqa: BLE001
+        logger.exception("LLM call failed for LINE user %s", user_id)
+        reply = f"⚠️ 我這邊暫時遇到問題，再試一次（{type(e).__name__}）"
+
+    await _add_message(sid, "assistant", reply)
+    return reply
+
+
+async def scan_timeouts(idle_minutes: Optional[int] = None) -> list[dict]:
+    """回傳 idle 超過 N 分鐘的 active session（已 mark ended、reason=timeout）。
+
+    呼叫者拿到 user_id 後負責 push 告別訊息（避免本模組 import LINE SDK）。
+    """
+    if not _DATABASE_URL:
+        return []
+    minutes = idle_minutes if idle_minutes is not None else _TIMEOUT_MINUTES
+    conn = await _connect()
+    try:
+        rows = await conn.fetch(
+            "UPDATE line_sessions SET ended_at = NOW(), end_reason = 'timeout' "
+            "WHERE ended_at IS NULL "
+            "  AND last_message_at < NOW() - ($1 || ' minutes')::interval "
+            "RETURNING id, user_id",
+            str(minutes),
+        )
+        return [dict(r) for r in rows]
+    finally:
+        await conn.close()
+
+
+# ──────────────────────────────────────────────────────────────────
+# 結束關鍵字 + 告別訊息（從 rag-kit ch5 直抄）
+# ──────────────────────────────────────────────────────────────────
+
+END_KEYWORDS = {
+    "bye", "Bye", "BYE",
+    "/end", "/bye",
+    "end", "End",
+    "再見", "掰掰", "結束", "結束對話", "下次見",
+}
+
+GOODBYE_USER_INITIATED = "好的，這次對話結束 ✅\n再傳訊息給我就會開始新對話、記憶會重置。"
+GOODBYE_TIMEOUT = "🌙 30 分鐘沒互動，這次對話自動結束。\n再傳訊息給我就會開始新對話、記憶會重置。"
+
+
+def is_end_keyword(text: str) -> bool:
+    return text.strip() in END_KEYWORDS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,26 @@ services:
       - ./litellm-config.yaml:/app/config.yaml:ro
     network_mode: host    # 為了能直接打 Pi5 Tailscale IP (100.74.6.41)
 
+  session-scanner:
+    # 每 60s 戳 ai-eva 的 /tasks/scan-timeouts，掃 idle 過久的 LINE session，
+    # mark ended + push 告別訊息。container 內部走 ai-eva:7860（同 compose network）。
+    image: curlimages/curl:8.10.1
+    container_name: ai-eva-session-scanner
+    restart: unless-stopped
+    depends_on:
+      - ai-eva
+    environment:
+      SESSION_SCAN_TOKEN: ${SESSION_SCAN_TOKEN}
+    entrypoint: ["sh", "-c"]
+    command:
+      - |
+        while true; do
+          curl -fsS -X POST http://ai-eva:7860/tasks/scan-timeouts \
+            -H "X-Scan-Token: $$SESSION_SCAN_TOKEN" \
+            >/dev/null 2>&1 || true
+          sleep 60
+        done
+
   rabbitmq:
     image: rabbitmq:3.13-management-alpine
     container_name: ai-eva-rabbitmq

--- a/docs/line-session-memory.md
+++ b/docs/line-session-memory.md
@@ -1,0 +1,129 @@
+# LINE Session Memory（Phase 1）
+
+> LINE bot 從 stateless 升級成「對話式記憶」：每位 user 進來開 session，記 12 輪 context；30 min idle 自動結束、push 告別。
+> 設計來源：[虎科大 ch5 LINE Bot 對話記憶](https://hackmd.io/@yillkid/rk_kVbxlfl)（同台機器 `4-learn/rag-kit/apps/huwei_landmarks/`），抄出來改 LiteLLM + asyncpg。
+
+## 拓樸
+
+```
+LINE 使用者
+   ↓ HTTPS
+beta-eva.4impact.cc / eva.4impact.cc   ← Cloudflare Tunnel
+   ↓
+ai-eva container :7860
+   ├─ /webhook/line             收 LINE event
+   │    ├─ end keyword？        → end_session + reply 告別
+   │    └─ 一般文字             → session.chat() → reply
+   └─ /tasks/scan-timeouts      scan_timeouts() + push 告別
+        ↑
+session-scanner sidecar
+   每 60s curl POST + X-Scan-Token
+        ↓
+PG (ai-eva-postgres)
+   line_sessions          ┐ 兩張新表（跟 chainlit 既有 thread/users 並存）
+   line_session_messages  ┘
+```
+
+## 兩張表
+
+| 表 | 欄位 | 用途 |
+|---|---|---|
+| `line_sessions` | `id / user_id / started_at / last_message_at / ended_at / end_reason / summary` | 一筆 = 一段對話。`ended_at IS NULL` 即 active |
+| `line_session_messages` | `id / session_id / role / content / created_at` | role = `user` / `assistant`，按 id 排序組 context |
+
+啟動時 `ensure_session_tables()` 自動 `CREATE TABLE IF NOT EXISTS`，不用 alembic。
+
+## 對話流程（happy path）
+
+1. user 傳訊：`你好`
+2. `line.py /webhook/line` → `_handle_event` text 分支
+3. 非 end keyword → `line_session.chat(user_id, text)`：
+   - 撈 active session（沒有就 `start_session`）
+   - `INSERT user message` + 更新 `last_message_at`
+   - 撈最近 12 則歷史
+   - `messages = [system_prompt] + history` → `make_llm(api_key=LITELLM_LINE_KEY).ainvoke(...)`
+   - `INSERT assistant message` + 回傳 reply
+4. `_line_reply(reply_token, answer)`
+
+## 結束（兩種）
+
+### A. 使用者自己喊結束（reply 模式）
+
+End keywords：`bye / Bye / BYE / end / End / /end / /bye / 再見 / 掰掰 / 結束 / 結束對話 / 下次見`
+
+webhook 內：
+- `line_session.is_end_keyword(text)` → True
+- `end_session(sess.id, "user")` 
+- `_line_reply(reply_token, GOODBYE_USER_INITIATED)` ← 用 reply token（免費 quota）
+
+### B. Idle 30 min（push 模式）
+
+`session-scanner` sidecar 每 60s POST `/tasks/scan-timeouts`：
+- `scan_timeouts()` 一個 UPDATE 同時 mark ended + return 逾時的 (id, user_id)
+- 對每筆 `push_to_user(user_id, GOODBYE_TIMEOUT)` ← push API（吃 quota，但是 user 已沒在線、沒 reply token 可用）
+
+## env vars
+
+| Key | 預設 | 說明 |
+|---|---|---|
+| `SESSION_SCAN_TOKEN` | （必填）| sidecar curl 戳 `/tasks/scan-timeouts` 用的 `X-Scan-Token`；沒設 endpoint 直接 503 |
+| `SESSION_TIMEOUT_MINUTES` | `30` | idle 多久算逾時 |
+| `SESSION_CONTEXT_TURNS` | `12` | LLM context 最多塞幾則歷史 |
+| `LITELLM_LINE_KEY` | （沿用 M3）| LINE bot 專用 virtual key，session.chat() 走這把算錢 |
+
+## docker-compose 新增 service
+
+```yaml
+session-scanner:
+  image: curlimages/curl:8.10.1
+  depends_on: [ai-eva]
+  environment:
+    SESSION_SCAN_TOKEN: ${SESSION_SCAN_TOKEN}
+  entrypoint: ["sh", "-c"]
+  command:
+    - |
+      while true; do
+        curl -fsS -X POST http://ai-eva:7860/tasks/scan-timeouts \
+          -H "X-Scan-Token: $$SESSION_SCAN_TOKEN" \
+          >/dev/null 2>&1 || true
+        sleep 60
+      done
+```
+
+走 docker compose network 內網 `http://ai-eva:7860`、不對外暴露。`||true` 避免 ai-eva 重啟期間 curl 失敗讓 sidecar exit。
+
+## 手動驗證
+
+```bash
+# 1. sidecar 戳得通 → expect "ended:0, pushed:0"
+docker exec ai-eva-session-scanner sh -c \
+  'curl -s -X POST http://ai-eva:7860/tasks/scan-timeouts \
+     -H "X-Scan-Token: $SESSION_SCAN_TOKEN"'
+
+# 2. 沒 token 直接擋
+curl -s -X POST http://localhost:7860/tasks/scan-timeouts   # expect 503
+
+# 3. 錯 token 擋
+curl -s -X POST http://localhost:7860/tasks/scan-timeouts \
+  -H "X-Scan-Token: wrong"                                  # expect 403
+
+# 4. LINE 端：傳「你好」→ 回覆有印象，連續對話 LLM 看得到前一句
+# 5. 傳「bye」→ 收到 GOODBYE_USER_INITIATED + 下一句重啟 session
+# 6. 不要互動 31 分鐘 → 收到 GOODBYE_TIMEOUT (push)
+```
+
+PG 端確認：
+```sql
+SELECT user_id, COUNT(*) FILTER (WHERE ended_at IS NULL) AS active,
+       COUNT(*) AS total
+FROM line_sessions GROUP BY user_id;
+
+SELECT session_id, role, left(content, 40) FROM line_session_messages
+ORDER BY id DESC LIMIT 20;
+```
+
+## 後續
+
+- **Phase 2**：summary 欄目前都 NULL；end 時可以 call LLM 寫一句總結存起來，給「之前我們聊過 X」用
+- **跨 surface 共用**：把 session memory 拉成 `app/memory/` 模組，Chainlit web `on_message` 也可吃同樣的記憶
+- **管理介面**：admin hub 加 `/admin/sessions` 看 active / 結束統計


### PR DESCRIPTION
## Summary

LINE bot 從 stateless 升級成「對話式記憶」：
- **記 12 輪 context** — 連續對話、bot 看得到前一句
- **bye / 再見 / 結束 / /end / 下次見 …** → reply 告別 + 收掉 session
- **idle 30 min** → push 告別（sidecar 每 60s 掃）

設計來源：虎科大 ch5 LINE Bot 對話記憶（同台機器 \`4-learn/rag-kit/apps/huwei_landmarks\`），改成純 asyncpg + LiteLLM。

## 變更

- \`app/surfaces/line_session.py\` — 新檔，session 生命週期 + chat + scan
- \`app/surfaces/line.py\` — text 分支改走 session.chat()、加 \`/tasks/scan-timeouts\`
- \`docker-compose.yml\` — 加 \`session-scanner\` sidecar（curlimages/curl，每 60s 戳 endpoint）
- \`docs/line-session-memory.md\` — 完整設計文件
- env 新增 \`SESSION_SCAN_TOKEN\` / \`SESSION_TIMEOUT_MINUTES\` / \`SESSION_CONTEXT_TURNS\`

## 兩張新 PG 表

- \`line_sessions(id, user_id, started_at, last_message_at, ended_at, end_reason, summary)\`
- \`line_session_messages(id, session_id, role, content, created_at)\`

啟動時 \`ensure_session_tables()\` \`CREATE TABLE IF NOT EXISTS\`，跟 chainlit 既有 thread/users 並存。

## Test plan

- [x] beta 容器重啟、表正常建立
- [x] \`/tasks/scan-timeouts\` 沒 token 403、錯 token 403、對的 token 200
- [x] 塞 fake 逾時 session → scan 回 \`{ended:1, pushed:0}\` + PG 標記 ended_at + end_reason='timeout'
- [ ] LINE 端真實對話：傳兩句確認 bot 記憶連貫
- [ ] LINE 端傳 \`bye\` 收到 GOODBYE_USER_INITIATED
- [ ] 等 31 分鐘確認 push GOODBYE_TIMEOUT

🤖 Generated with [Claude Code](https://claude.com/claude-code)