### PR TITLE
feat(registry): app meta 加 owner + id collision raise

### DIFF
--- a/app/apps/_registry.py
+++ b/app/apps/_registry.py
@@ -2,8 +2,13 @@
 App registry: auto-discover apps/*/, expose manifest + dispatcher.
 
 Each app package must define:
-  - meta.py with META dict: {id, label, icon, trigger?, is_default?, show_in_menu?, enabled?}
+  - meta.py with META dict: {id, label, icon, owner?, trigger?, is_default?, show_in_menu?, enabled?}
   - handler.py with async handle(payload: str, msg) coroutine
+
+Owner namespace:
+  meta["owner"] 預設 "yillkid"。未來其他 owner（虎科 / 縣府 / …）的 apps 進來時必須
+  自己宣告 owner。完整命名 = f"{owner}.{id}"；目前只有 yillkid、id 撞名直接 raise，
+  避免 silent override。
 """
 import logging
 from importlib import import_module
@@ -14,10 +19,13 @@ logger = logging.getLogger(__name__)
 
 Handler = Callable[[str, object], Awaitable[None]]
 
+DEFAULT_OWNER = "yillkid"
+
 
 class App:
     def __init__(self, meta: dict, handle: Handler):
         self.id: str = meta["id"]
+        self.owner: str = meta.get("owner", DEFAULT_OWNER)
         self.label: str = meta.get("label", self.id)
         self.icon: str = meta.get("icon", "🔧")
         self.cl_icon: str = meta.get("cl_icon", "Sparkles")  # Lucide icon for Chainlit
@@ -27,6 +35,10 @@ class App:
         self.enabled: bool = bool(meta.get("enabled", True))
         self.description: str = meta.get("description", "")
         self.handle: Handler = handle
+
+    @property
+    def full_id(self) -> str:
+        return f"{self.owner}.{self.id}"
 
 
 _APPS: dict[str, App] = {}
@@ -46,10 +58,20 @@ def discover() -> dict[str, App]:
             meta = import_module(f"app.apps.{sub.name}.meta").META
             handle = import_module(f"app.apps.{sub.name}.handler").handle
             app = App(meta, handle)
+            if app.id in _APPS:
+                existing = _APPS[app.id]
+                raise RuntimeError(
+                    f"App id collision: '{app.id}' from owner='{app.owner}' conflicts with "
+                    f"existing owner='{existing.owner}'. Rename one, or switch dispatch to "
+                    f"full_id (<owner>.<id>) form."
+                )
             _APPS[app.id] = app
             if app.is_default:
                 _DEFAULT = app
-            logger.info("Loaded app: %s (trigger=%s, default=%s)", app.id, app.trigger, app.is_default)
+            logger.info(
+                "Loaded app: %s (owner=%s, trigger=%s, default=%s)",
+                app.id, app.owner, app.trigger, app.is_default,
+            )
         except Exception as e:
             logger.exception("Failed to load app '%s': %s", sub.name, e)
 


### PR DESCRIPTION
## Summary

為未來多 owner（虎科 / 縣府 / …）apps 鋪路，目前單一使用者、預設 \`owner=yillkid\`：

- \`App\` class 加 \`owner\`（default \`yillkid\`）+ \`full_id\` 屬性（\`<owner>.<id>\`）
- \`discover()\` 對 id 撞名直接 raise（含 owner 提示），避免 silent override
- 日誌加 owner 欄位

backend-only 改動；前端 / dispatch / Chainlit command id 不變（headless 原則：分流邏輯不靠 UI）。

## Test plan

- [x] beta 重 build + 重啟，日誌印「Loaded app: hello_world (owner=yillkid, ...)」
- [x] 既有三個 apps（plain_chat / hello_world / web_search）都用 default owner，無 collision
- [ ] 未來測 collision：手動建兩個 meta.py 同 \`id\` 不同 \`owner\` → 應 raise

🤖 Generated with [Claude Code](https://claude.com/claude-code)