### PR TITLE
feat(project): owner → project + PG projects registry

### DIFF
--- a/app/apps/_registry.py
+++ b/app/apps/_registry.py
@@ -2,13 +2,14 @@
 App registry: auto-discover apps/*/, expose manifest + dispatcher.
 
 Each app package must define:
-  - meta.py with META dict: {id, label, icon, owner?, trigger?, is_default?, show_in_menu?, enabled?}
+  - meta.py with META dict: {id, label, icon, project?, trigger?, is_default?, show_in_menu?, enabled?}
   - handler.py with async handle(payload: str, msg) coroutine
 
-Owner namespace:
-  meta["owner"] 預設 "yillkid"。未來其他 owner（虎科 / 縣府 / …）的 apps 進來時必須
-  自己宣告 owner。完整命名 = f"{owner}.{id}"；目前只有 yillkid、id 撞名直接 raise，
-  避免 silent override。
+Project namespace:
+  meta["project"] 預設 "yillkid"。project = 擁有 {apps + nodes + profile} 的範圍
+  （虎科 / 縣府 / 機器人部門 / 俊毓個人 …），不是登入帳號。完整命名 = f"{project}.{id}"；
+  目前只有 yillkid、id 撞名直接 raise，避免 silent override。
+  project 的 profile（LINE 收件人 / 聯絡人）存在 PG projects 表，見 app/projects/registry.py。
 """
 import logging
 from importlib import import_module
@@ -19,13 +20,14 @@ logger = logging.getLogger(__name__)
 
 Handler = Callable[[str, object], Awaitable[None]]
 
-DEFAULT_OWNER = "yillkid"
+DEFAULT_PROJECT = "yillkid"
 
 
 class App:
     def __init__(self, meta: dict, handle: Handler):
         self.id: str = meta["id"]
-        self.owner: str = meta.get("owner", DEFAULT_OWNER)
+        # 向後相容：舊欄位名 owner 仍接受，逐步遷到 project
+        self.project: str = meta.get("project", meta.get("owner", DEFAULT_PROJECT))
         self.label: str = meta.get("label", self.id)
         self.icon: str = meta.get("icon", "🔧")
         self.cl_icon: str = meta.get("cl_icon", "Sparkles")  # Lucide icon for Chainlit
@@ -38,7 +40,7 @@ class App:
 
     @property
     def full_id(self) -> str:
-        return f"{self.owner}.{self.id}"
+        return f"{self.project}.{self.id}"
 
 
 _APPS: dict[str, App] = {}
@@ -61,16 +63,16 @@ def discover() -> dict[str, App]:
             if app.id in _APPS:
                 existing = _APPS[app.id]
                 raise RuntimeError(
-                    f"App id collision: '{app.id}' from owner='{app.owner}' conflicts with "
-                    f"existing owner='{existing.owner}'. Rename one, or switch dispatch to "
-                    f"full_id (<owner>.<id>) form."
+                    f"App id collision: '{app.id}' from project='{app.project}' conflicts with "
+                    f"existing project='{existing.project}'. Rename one, or switch dispatch to "
+                    f"full_id (<project>.<id>) form."
                 )
             _APPS[app.id] = app
             if app.is_default:
                 _DEFAULT = app
             logger.info(
-                "Loaded app: %s (owner=%s, trigger=%s, default=%s)",
-                app.id, app.owner, app.trigger, app.is_default,
+                "Loaded app: %s (project=%s, trigger=%s, default=%s)",
+                app.id, app.project, app.trigger, app.is_default,
             )
         except Exception as e:
             logger.exception("Failed to load app '%s': %s", sub.name, e)
@@ -104,3 +106,20 @@ def get_by_id(app_id: str) -> App | None:
 def default_app() -> App | None:
     discover()
     return _DEFAULT
+
+
+# 平台內建 project — 通用 app（chat / search …）放這，全 project 可見
+CORE_PROJECT = "core"
+
+
+def apps_for_project(project: str) -> list[App]:
+    """某個 project 看得到的 app = 自己的 + core 的。
+
+    給未來 project-aware 的 surface 用（機器人 / 多租戶 web）。
+    目前 webchat 仍走 chainlit_commands() 顯示全部，不依賴這個。
+    """
+    discover()
+    return [
+        a for a in _APPS.values()
+        if a.project == project or a.project == CORE_PROJECT
+    ]

--- a/app/apps/hello_world/meta.py
+++ b/app/apps/hello_world/meta.py
@@ -1,5 +1,6 @@
 META = {
     "id": "hello_world",
+    "project": "core",
     "label": "模型對照",
     "icon": "🪞",
     "cl_icon": "Scale",

--- a/app/apps/plain_chat/meta.py
+++ b/app/apps/plain_chat/meta.py
@@ -1,5 +1,6 @@
 META = {
     "id": "plain_chat",
+    "project": "core",
     "label": "對話",
     "icon": "💬",
     "cl_icon": "MessageCircle",

--- a/app/apps/web_search/meta.py
+++ b/app/apps/web_search/meta.py
@@ -1,5 +1,6 @@
 META = {
     "id": "web_search",
+    "project": "core",
     "label": "網頁搜尋",
     "icon": "🔍",
     "cl_icon": "Globe",  # Lucide icon name for Chainlit's composer

--- a/app/main.py
+++ b/app/main.py
@@ -34,20 +34,22 @@ if ADMIN_PASS:
 
 discover()
 
-# 啟動時建 line_users + line_sessions/line_session_messages 表（給 LINE 用）。
+# 啟動時建表：line_users / line_sessions / line_session_messages（LINE 用）+ projects。
 # Chainlit 沒 on_app_startup decorator，這裡直接用 asyncio fire-and-forget。
 from app.surfaces import line_session  # noqa: E402
+from app.projects import registry as project_registry  # noqa: E402
 
 
-async def _init_line_tables():
+async def _init_tables():
+    await project_registry.ensure_projects_table()
     await line_surface.ensure_line_table()
     await line_session.ensure_session_tables()
 
 
 try:
-    asyncio.get_event_loop().create_task(_init_line_tables())
+    asyncio.get_event_loop().create_task(_init_tables())
 except RuntimeError:
-    asyncio.run(_init_line_tables())
+    asyncio.run(_init_tables())
 
 # 啟 RabbitMQ consumer（如果 .env 有設 RABBITMQ_URL）
 queue_consumer.start_in_background()

--- a/app/projects/registry.py
+++ b/app/projects/registry.py
@@ -1,0 +1,110 @@
+"""Project registry — PG 表 `projects`。
+
+project = 擁有 {apps + nodes + profile} 的範圍（虎科 / 縣府 / 機器人部門 / 俊毓個人 …），
+不是登入帳號。identity（Chainlit password / CF Access email / LINE userId）另外映射到 project。
+
+這層只管 project 的「身分 + profile」：
+  - id        project 代號（app meta 的 project 欄位指這個）
+  - label     人看的名字
+  - line_recipient  該 project 預設 push 的 LINE userId
+  - contacts  聯絡人 map，e.g. {"chika": "Uxxxx"}（主動通報用）
+  - metadata  其餘擴充
+
+app↔project 的歸屬在 app meta（project 欄位）+ _registry；這裡不存 app/node。
+node registry 之後跟機器人部門合寫（capability provider）。
+
+用純 asyncpg，跟 line.py / line_session.py 同風格。啟動時 ensure_projects_table() 建表 + seed。
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Optional
+
+import asyncpg
+
+logger = logging.getLogger(__name__)
+
+_DATABASE_URL = os.getenv("DATABASE_URL", "")
+
+CORE_PROJECT = "core"
+DEFAULT_PROJECT = "yillkid"
+
+
+def _pg_url() -> str:
+    return _DATABASE_URL.replace("postgresql+asyncpg://", "postgresql://")
+
+
+async def _connect() -> asyncpg.Connection:
+    return await asyncpg.connect(_pg_url())
+
+
+# 啟動 seed：平台內建 + 俊毓個人。line_recipient 之後可在 DB 改。
+_SEED = [
+    {"id": CORE_PROJECT, "label": "平台內建", "line_recipient": None, "contacts": {}},
+    {
+        "id": DEFAULT_PROJECT,
+        "label": "俊毓個人",
+        "line_recipient": os.getenv("DEFAULT_LINE_RECIPIENT") or None,
+        "contacts": {},
+    },
+]
+
+
+async def ensure_projects_table() -> None:
+    if not _DATABASE_URL:
+        logger.warning("DATABASE_URL not set; project registry disabled")
+        return
+    conn = await _connect()
+    try:
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS projects (
+                id             TEXT PRIMARY KEY,
+                label          TEXT NOT NULL,
+                line_recipient TEXT,
+                contacts       JSONB DEFAULT '{}'::jsonb,
+                metadata       JSONB DEFAULT '{}'::jsonb,
+                created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            """
+        )
+        # seed（已存在就不覆蓋，避免蓋掉手動改過的 profile）
+        for p in _SEED:
+            await conn.execute(
+                """
+                INSERT INTO projects (id, label, line_recipient, contacts)
+                VALUES ($1, $2, $3, $4::jsonb)
+                ON CONFLICT (id) DO NOTHING
+                """,
+                p["id"], p["label"], p["line_recipient"], json.dumps(p["contacts"]),
+            )
+        logger.info("projects table ready (seeded %s)", [p["id"] for p in _SEED])
+    finally:
+        await conn.close()
+
+
+async def get_project(project_id: str) -> Optional[dict]:
+    if not _DATABASE_URL:
+        return None
+    conn = await _connect()
+    try:
+        row = await conn.fetchrow(
+            "SELECT id, label, line_recipient, contacts, metadata FROM projects WHERE id = $1",
+            project_id,
+        )
+        return dict(row) if row else None
+    finally:
+        await conn.close()
+
+
+async def list_projects() -> list[dict]:
+    if not _DATABASE_URL:
+        return []
+    conn = await _connect()
+    try:
+        rows = await conn.fetch("SELECT id, label, line_recipient FROM projects ORDER BY id")
+        return [dict(r) for r in rows]
+    finally:
+        await conn.close()


### PR DESCRIPTION
## Summary

把 app 的 `owner` 概念 rename 成 **project**（= 擁有 apps + nodes + profile 的範圍，不是登入帳號）並落地成 PG 表。為分散式 capability 架構（[#25](https://github.com/towNingtek/ai-eva/issues/25)）鋪 project principal 地基。

### 設計決策（與用戶對齊）
- **project ≠ 帳號**：project = 虎科 / 縣府 / 機器人部門 / 俊毓個人…；identity（password / CF Access / LINE userId）另外映射到 project
- **core 平台 project**：通用內建 app（chat / search / 模型對照）歸 `core`，全租戶可見；`yillkid` 留給俊毓自己的業務 app
- **安全 default**：沒宣告 project 的 app → 落 `yillkid`（私有），不會誤洩到 core

## 變更
- `_registry.py`：owner→project（meta 向後相容仍收 `owner`）；加 `apps_for_project()` 可見性 helper（自己 project + core）
- 三個內建 app 標 `project: "core"`
- `app/projects/registry.py`：PG `projects` 表 + ensure + seed + get/list，純 asyncpg
- `main.py` 啟動 init projects 表

## 不碰的東西（webchat 安全保證）
- dispatch / surfaces / chainlit_commands 都沒動 → webchat 行為 0 變化
- 可見性 scoping 只做成 helper，待 project-aware surface 接

## Test plan
- [x] beta rebuild：三 app 載入 `project=core`
- [x] `projects` 表建立 + seed `core` / `yillkid`（yillkid 帶 LINE recipient）
- [x] webchat `http://localhost:7860` 回 200、選單照舊
- [ ] node registry + capability（待跟機器人部門合寫）

🤖 Generated with [Claude Code](https://claude.com/claude-code)