### PR TITLE
fix(device): /device/img 路由被 Chainlit SPA catch-all 蓋掉

### DIFF
--- a/app/surfaces/device.py
+++ b/app/surfaces/device.py
@@ -158,3 +158,13 @@ async def device_img(filename: str):
     if not fp.is_file():
         raise HTTPException(404, "not found")
     return Response(content=fp.read_bytes(), media_type="image/jpeg")
+
+
+# Chainlit 掛了 SPA 萬用 GET 路由（/{path:path}），會搶先吃掉 GET /device/img/*
+# 並回傳 SPA 的 index.html（LINE 抓圖就拿到 HTML → 顯示「系統發生問題」）。
+# Starlette 依「註冊順序」配對，所以把本路由提到 router 最前面，搶在 catch-all 前。
+for _r in list(fastapi_app.router.routes):
+    if getattr(_r, "path", None) == "/device/img/{filename}":
+        fastapi_app.router.routes.remove(_r)
+        fastapi_app.router.routes.insert(0, _r)
+        break


### PR DESCRIPTION
## 問題
LINE 抓 device 影像顯示「系統發生問題」。根因：Chainlit 掛了萬用 GET `/{path:path}` 服務 SPA，Starlette 照註冊順序配對，`device.py` 較晚 import → `GET /device/img/*` 被 catch-all 搶走、回 index.html。LINE 抓到 HTML 不是 JPEG。

## 修法
把 `/device/img/{filename}` 提到 router 最前面（搶在 catch-all 前）。

## 驗證
beta：localhost + 公開 URL（beta-eva.4impact.cc）都回 image/jpeg；LINE「幫我拍照」→ pi4 真機拍兩張 → `pushed=True` + 圖正常顯示在 LINE。

🤖 Generated with [Claude Code](https://claude.com/claude-code)