### PR TITLE
feat(auth): multi-issuer RS256 驗章層 (#37 / SSO #89)

### DIFF
--- a/app/auth/issuers.py
+++ b/app/auth/issuers.py
@@ -1,0 +1,110 @@
+"""Multi-issuer 驗章層（issue #37 契約 A / tplanet #89 SSO）。
+
+ai-eva 是多 project 信任中樞：每個發起專案（tplanet CMS、未來 IoT 玉設…）是一個
+**issuer**，各自簽 RS256 handoff token，ai-eva **只用公鑰驗、不簽**（被攻破也無法偽造）。
+
+verify_handoff(token) 做三件事：
+1. 認 issuer（token 的 `iss`）→ 查 registry 拿它的 jwks_url / audience / project
+2. 用該 issuer 的 JWKS 公鑰驗 RS256 簽章 + `aud` + `exp`（擋重放/過期）
+3. 回 identity：**把 token 映成 project + tenant + user**（正是 #31 卡住的 identity→project）
+
+issuer registry 目前 hardcode dev 那筆；上 stable 補各環境的 jwks（per-env issuer key）。
+之後可挪去 DB / project registry。
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any
+
+import httpx
+import jwt
+from jwt.algorithms import RSAAlgorithm
+
+logger = logging.getLogger(__name__)
+
+# ── issuer registry（誰可信 + 怎麼驗 + 映哪個 project）──────────────
+ISSUERS: dict[str, dict] = {
+    "tplanet-cms": {
+        "jwks_url": "https://dev.4impact.cc/api/tools/jwks",
+        "manifest_url": "https://dev.4impact.cc/api/tools/manifest",
+        "audience": "ai-eva",
+        "project": "tplanet",   # tenant 取自 token 的 tenant_id
+    },
+}
+
+_AUDIENCE_DEFAULT = "ai-eva"
+
+# ── JWKS 快取（kid→公鑰物件；含 TTL，支援輪替）─────────────────────
+_JWKS_CACHE: dict[str, dict] = {}   # jwks_url -> {"keys": {kid: pubkey}, "exp": ts}
+_JWKS_TTL = 600   # 10 分鐘；輪替時最多 stale 這麼久（要更即時可在 kid miss 時強制 refresh）
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _fetch_jwks(jwks_url: str, *, force: bool = False) -> dict[str, Any]:
+    """抓 JWKS → 解析成 {kid: 公鑰物件}，帶 TTL 快取。"""
+    cached = _JWKS_CACHE.get(jwks_url)
+    if cached and not force and cached["exp"] > _now():
+        return cached["keys"]
+    resp = httpx.get(jwks_url, timeout=10)
+    resp.raise_for_status()
+    keys = {}
+    for jwk in resp.json().get("keys", []):
+        kid = jwk.get("kid")
+        if not kid:
+            continue
+        keys[kid] = RSAAlgorithm.from_jwk(json.dumps(jwk))
+    _JWKS_CACHE[jwks_url] = {"keys": keys, "exp": _now() + _JWKS_TTL}
+    logger.info("fetched JWKS %s: %d key(s)", jwks_url, len(keys))
+    return keys
+
+
+def _pubkey_for(issuer: dict, kid: str):
+    keys = _fetch_jwks(issuer["jwks_url"])
+    if kid not in keys:
+        # kid miss → 可能剛輪替，強制 refresh 一次
+        keys = _fetch_jwks(issuer["jwks_url"], force=True)
+    key = keys.get(kid)
+    if key is None:
+        raise ValueError(f"kid '{kid}' not in JWKS {issuer['jwks_url']}")
+    return key
+
+
+def verify_handoff(token: str) -> dict:
+    """驗 RS256 handoff token → 回 identity dict。
+
+    raises:
+      jwt.PyJWTError（簽章/aud/exp/iss 不對）、ValueError（未知 issuer / kid）
+    回：
+      {"project","tenant_id","user_id","email","issuer","claims"}
+    """
+    # 先看未驗 header / iss（決定用哪個 issuer 的公鑰）
+    header = jwt.get_unverified_header(token)
+    kid = header.get("kid")
+    unverified = jwt.decode(token, options={"verify_signature": False})
+    iss = unverified.get("iss")
+
+    issuer = ISSUERS.get(iss or "")
+    if issuer is None:
+        raise ValueError(f"unknown issuer: {iss!r}")
+
+    pub = _pubkey_for(issuer, kid)
+    claims = jwt.decode(
+        token,
+        pub,
+        algorithms=["RS256"],
+        audience=issuer.get("audience", _AUDIENCE_DEFAULT),
+        issuer=iss,
+    )
+    return {
+        "project": issuer["project"],
+        "tenant_id": claims.get("tenant_id"),
+        "user_id": claims.get("user_id"),
+        "email": claims.get("email"),
+        "issuer": iss,
+        "claims": claims,
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ greenlet>=3,<4
 httpx>=0.27,<1.0
 ddgs>=6,<10
 aio-pika>=9,<10
+pyjwt[crypto]>=2.10,<3


### PR DESCRIPTION
實作 [#37](https://github.com/towNingtek/ai-eva/issues/37) 契約 A（驗章）/ tplanet #89 的 ai-eva 側。

## 做了什麼
- `app/auth/issuers.py`：`ISSUERS` registry + `verify_handoff(token)`
- JWKS 抓取 + kid 快取（TTL 10min，kid miss 強制 refresh → 支援金鑰輪替）
- RS256 驗章 + `audience`(aud=ai-eva, 擋重放) + `issuer` + `exp`
- **token → identity**：映成 `{project, tenant_id, user_id, email}` ← 解掉 #31 的 identity→project
- requirements 顯式加 `pyjwt[crypto]`

## 測試（實跑）
- self-signed RS256 round-trip → identity 正確
- `aud` 錯 → `InvalidAudienceError` 擋掉
- 打 **CMS live dev JWKS**（`https://dev.4impact.cc/api/tools/jwks`，kid `lC64VgmrKXJiMYyj`）→ 抓取 + 公鑰解析成功

## 範圍
- additive、**無 caller**（SSO handoff 入口 + #35 副駕才 wire）
- dev issuer `tplanet-cms` 已登記；stable 補各環境 jwks
- 配 #38 的 ToolRuntime，組成「驗章 → manifest → 帶 JWT 呼叫」整鏈的前兩塊

🤖 Generated with [Claude Code](https://claude.com/claude-code)