### PR TITLE
feat(sso): wire CMS 副駕進 Chainlit (#35)

### DIFF
--- a/app/auth/issuers.py
+++ b/app/auth/issuers.py
@@ -123,4 +123,7 @@ def fetch_manifest(issuer_id: str, token: str, *, timeout: float = 15.0) -> dict
         raise ValueError(f"issuer {issuer_id!r} has no manifest_url")
     r = httpx.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=timeout)
     r.raise_for_status()
-    return r.json()
+    body = r.json()
+    # CMS 回 {"success":true,"data":{callback_base,credential,tools}}；拆 data 信封交給 ToolRuntime。
+    # 若無信封（其他 issuer 直接回 manifest）則原樣回。
+    return body.get("data", body) if isinstance(body, dict) else body

--- a/app/core/copilot.py
+++ b/app/core/copilot.py
@@ -1,0 +1,70 @@
+"""CMS 副駕 tool-loop（issue #35，讀類）。
+
+給一個已載入 manifest 的 ToolRuntime + 使用者問句，跑「LLM 選工具 → ToolRuntime 執行
+→ 結果餵回 → 回答」的迴圈。只用 manifest 白名單內的工具（ToolRuntime deny-by-default）。
+
+安全：寫類工具回 need_confirm 時**不自動執行**，原樣交給 LLM 轉述「需要確認」。
+#35 範圍是讀類，manifest v1 全 read（needs_confirm=false）→ 直接跑。
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+from app.core.llm import make_llm
+
+logger = logging.getLogger(__name__)
+
+COPILOT_SYSTEM = (
+    "你是使用者在 CMS 的 AI 副駕。你只能用系統提供的工具查資料，"
+    "不要臆測沒有的資訊。查到什麼就如實回答，查不到就說查不到。"
+    "用繁體中文、簡潔。涉及需要確認的寫入操作時，先說明再請使用者確認。\n"
+    "重要：當某工具需要專案 uuid 但使用者沒提供時，**先呼叫 list_my_projects 取得**，"
+    "再用拿到的 uuid 去查（例如查 SROI）。不要反過來要使用者提供 uuid。"
+)
+
+
+async def run_copilot(
+    runtime,
+    user_text: str,
+    history: list | None = None,
+    *,
+    api_key: str | None = None,
+    max_rounds: int = 4,
+) -> str:
+    """跑一輪副駕對話，回最終文字。
+
+    runtime: 已 load(manifest) 的 ToolRuntime
+    history: 之前的 langchain messages（可選）
+    """
+    tools = runtime.visible_tools()
+    llm = make_llm(api_key=api_key, streaming=False)
+    if tools:
+        llm = llm.bind_tools(tools)
+
+    msgs: list = [SystemMessage(content=COPILOT_SYSTEM)]
+    msgs += history or []
+    msgs.append(HumanMessage(content=user_text))
+
+    for _ in range(max_rounds):
+        resp: AIMessage = await llm.ainvoke(msgs)
+        msgs.append(resp)
+
+        tool_calls = getattr(resp, "tool_calls", None) or []
+        if not tool_calls:
+            return (resp.content or "").strip() or "（這次沒拿到回應）"
+
+        for tc in tool_calls:
+            name, args, tc_id = tc.get("name", ""), tc.get("args") or {}, tc.get("id", "")
+            result = await runtime.execute(name, args, confirmed=False)  # 寫類不自動 confirm
+            logger.info("copilot tool %s(%s) → %s", name, args, result.get("status"))
+            msgs.append(ToolMessage(
+                content=json.dumps(result, ensure_ascii=False),
+                tool_call_id=tc_id,
+            ))
+
+    # 用完 max_rounds 還在叫工具 → 收尾要它直接回答
+    final = await llm.ainvoke(msgs + [HumanMessage(content="請根據以上工具結果直接回答，不要再呼叫工具。")])
+    return (final.content or "").strip() or "（查了多輪仍未完成）"

--- a/app/main.py
+++ b/app/main.py
@@ -1,19 +1,22 @@
 import asyncio
 import logging
 import os
+from typing import Optional
 
 import chainlit as cl
 import chainlit.data as cl_data
 from chainlit.data.sql_alchemy import SQLAlchemyDataLayer
+from langchain_core.messages import AIMessage, HumanMessage
 
 from app.apps._registry import chainlit_commands, default_app, discover, get_by_id
+from app.core.copilot import run_copilot
 from app.core.storage import LocalStorageClient
 from app.dispatch import Envelope, handle_device_intent
 from app.nodes import commands as node_commands
 from app.settings import ROOT
 from app.surfaces import line as line_surface  # 註冊 /webhook/line route
 from app.surfaces import device as device_surface  # noqa: F401  # 註冊 /device/* route
-from app.surfaces import sso as sso_surface  # noqa: F401  # 註冊 /sso/handoff route
+from app.surfaces import sso as sso_surface  # noqa: F401  # 註冊 /sso/handoff route + SSO session
 from app.surfaces import queue_consumer  # RabbitMQ consumer 給 M4 cron push 用
 
 logger = logging.getLogger(__name__)
@@ -36,6 +39,33 @@ if ADMIN_PASS:
         if username == ADMIN_USER and password == ADMIN_PASS:
             return cl.User(identifier=username, metadata={"role": "admin"})
         return None
+
+
+# SSO（CMS 等 issuer）：/sso/handoff 種的 eva_sso cookie → 認證成 CMS 使用者。
+# 與上面的 password auth 共存（Chainlit headerAuth / passwordAuth 是獨立 flag）：
+# 有 cookie → header auth 認證；無 cookie → 退回 admin 密碼登入。
+@cl.header_auth_callback
+async def sso_header_auth(headers) -> Optional[cl.User]:
+    cookie = headers.get("cookie") or ""
+    sid = None
+    for part in cookie.split(";"):
+        k, _, v = part.strip().partition("=")
+        if k == "eva_sso":
+            sid = v
+            break
+    sess = sso_surface.get_sso_session(sid)
+    if not sess:
+        return None  # 無有效 SSO → 退回 password 登入
+    idn = sess["identity"]
+    return cl.User(
+        identifier=idn.get("email") or f'{idn["project"]}:{idn.get("user_id")}',
+        metadata={
+            "sso_session_id": sid,
+            "project": idn["project"],
+            "tenant_id": idn.get("tenant_id"),
+            "role": "cms-user",
+        },
+    )
 
 
 discover()
@@ -75,8 +105,31 @@ async def on_chat_resume(thread):
     await _register_commands()
 
 
+def _sso_session_for_current_user():
+    """目前 Chainlit user 若是 SSO 認證的，回它的 SSO session（含 ToolRuntime）；否則 None。"""
+    user = cl.user_session.get("user")
+    sid = (getattr(user, "metadata", None) or {}).get("sso_session_id") if user else None
+    return sso_surface.get_sso_session(sid) if sid else None
+
+
 @cl.on_chat_start
 async def on_start():
+    sess = _sso_session_for_current_user()
+    if sess:
+        # CMS 副駕模式：載入該帳號的 ToolRuntime，走 copilot
+        cl.user_session.set("cms_runtime", sess["runtime"])
+        cl.user_session.set("cms_history", [])
+        idn = sess["identity"]
+        tools = [t["function"]["name"] for t in sess["runtime"].visible_tools()]
+        await cl.Message(
+            content=(
+                f"嗨，我是你在 CMS 的 AI 副駕（{idn.get('email') or idn['project']}）。\n\n"
+                f"我可以幫你查：{', '.join(tools) or '（目前無可用工具）'}。\n"
+                "試試問「**列出我的專案**」或「**我的 SROI**」。"
+            )
+        ).send()
+        return
+
     await _register_commands()
     await cl.Message(
         content=(
@@ -91,6 +144,20 @@ async def on_start():
 async def on_message(msg: cl.Message):
     content = (msg.content or "").strip()
     if not content:
+        return
+
+    # CMS 副駕模式（SSO 認證）：用該帳號 manifest 的工具跑 copilot tool-loop。
+    runtime = cl.user_session.get("cms_runtime")
+    if runtime is not None:
+        history = cl.user_session.get("cms_history") or []
+        try:
+            ans = await run_copilot(runtime, content, history)
+        except Exception as e:  # noqa: BLE001
+            logger.exception("CMS copilot failed")
+            ans = f"⚠️ 查詢失敗，請再試一次（{type(e).__name__}）"
+        history += [HumanMessage(content=content), AIMessage(content=ans)]
+        cl.user_session.set("cms_history", history[-12:])
+        await cl.Message(content=ans).send()
         return
 
     # 沒選特定工具時，先看是不是要指揮裝置（function-calling）。

--- a/app/tools/runtime.py
+++ b/app/tools/runtime.py
@@ -65,6 +65,33 @@ class ToolRuntime:
         kind = (tool.get("kind") or "").lower()
         return kind != "read"   # 只有明確 read 才免確認；其餘（含缺漏）都要
 
+    @staticmethod
+    def _to_json_schema(params) -> dict:
+        """把 manifest 的 parameters 正規化成合法 JSON Schema（給 LLM）。
+
+        接受兩種：
+        - 已是 JSON Schema（含 type:object / properties）→ 原樣
+        - CMS 簡化格式 {name: {type, required, description}} → 轉成 object schema
+        - 空 / 非 dict → 空 object
+        """
+        if not isinstance(params, dict) or not params:
+            return {"type": "object", "properties": {}}
+        if params.get("type") == "object" or "properties" in params:
+            return params
+        props, required = {}, []
+        for name, spec in params.items():
+            spec = spec if isinstance(spec, dict) else {}
+            prop = {"type": spec.get("type", "string")}
+            if spec.get("description"):
+                prop["description"] = spec["description"]
+            props[name] = prop
+            if spec.get("required"):
+                required.append(name)
+        schema = {"type": "object", "properties": props}
+        if required:
+            schema["required"] = required
+        return schema
+
     # ── 給 LLM 的白名單 ───────────────────────────────────
     def visible_tools(self) -> list[dict]:
         """回 OpenAI function schema 清單（只有 manifest 內的；白名單外不存在）。"""
@@ -75,7 +102,7 @@ class ToolRuntime:
                 "function": {
                     "name": name,
                     "description": t.get("description", ""),
-                    "parameters": t.get("parameters") or {"type": "object", "properties": {}},
+                    "parameters": self._to_json_schema(t.get("parameters")),
                 },
             })
         return out
@@ -114,12 +141,17 @@ class ToolRuntime:
         if self._credential:
             headers["Authorization"] = f"Bearer {self._credential}"
 
+        # 送法：GET→query；POST→預設 form-encoded（CMS 端點吃 form，不吃 JSON），
+        # 工具可標 "encoding":"json" 改送 JSON body（給 JSON-based issuer）。
+        encoding = (tool.get("encoding") or "form").lower()
         try:
             async with httpx.AsyncClient(timeout=self._timeout) as cx:
                 if method == "GET":
                     r = await cx.get(url, params=args, headers=headers)
-                else:
+                elif encoding == "json":
                     r = await cx.request(method, url, json=args, headers=headers)
+                else:
+                    r = await cx.request(method, url, data=args, headers=headers)
         except Exception as e:  # noqa: BLE001
             logger.exception("ToolRuntime execute '%s' transport error", name)
             return {"status": "error", "reason": f"{type(e).__name__}: {e}", "tool": name}


### PR DESCRIPTION
header_auth(cookie)+on_chat_start 載 runtime+on_message copilot。實測 auth 共存(password+header 都 True)、真 SSO cookie 認證通、run_copilot 對真 CMS 答對。beta only(stable 待 CMS stable + registry)。🤖 Generated with [Claude Code](https://claude.com/claude-code)