### PR TITLE
feat(ui): SSO 進站 splash 消登入頁一閃 (#43)

### DIFF
--- a/.chainlit/config.toml
+++ b/.chainlit/config.toml
@@ -74,7 +74,8 @@ cot = "full"
 
 # Specify a Javascript file that can be used to customize the user interface.
 # The Javascript file can be served from the public directory.
-# custom_js = "/public/custom.js"
+# #43: SSO 進站 splash（只在有 eva_sso cookie 時蓋「登入中…」，避免登入頁一閃；standalone 不受影響）
+custom_js = "/public/custom.js"
 
 # Specify a custom font url.
 # custom_font = "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"

--- a/public/custom.js
+++ b/public/custom.js
@@ -1,2 +1,45 @@
-// Intentionally empty — Chainlit's native commands replaced our custom + menu.
-// Keep the file (referenced by .chainlit/config.toml) as a no-op.
+// #43：SSO 來源（帶 eva_sso cookie）進站時，session 解析完成前蓋一層「登入中…」splash，
+// 避免 Chainlit SPA 先 render 登入表單再切 chatroom 的那一閃。
+// 只在有 eva_sso cookie 時動作 → 沒 session 的 standalone 訪客完全不受影響（照常看登入頁）。
+(function () {
+  if (!/(^|;\s*)eva_sso=/.test(document.cookie)) return;  // 非 SSO 來源 → 不蓋，standalone 照舊
+
+  var splash = document.createElement("div");
+  splash.id = "eva-sso-splash";
+  splash.textContent = "登入中…";
+  Object.assign(splash.style, {
+    position: "fixed", inset: "0", zIndex: "99999",
+    display: "flex", alignItems: "center", justifyContent: "center",
+    background: "#ffffff", color: "#555",
+    font: "500 18px -apple-system, system-ui, 'Noto Sans TC', sans-serif",
+    transition: "opacity .3s ease",
+  });
+
+  function mount() {
+    if (document.body && !document.getElementById("eva-sso-splash")) {
+      document.body.appendChild(splash);
+    }
+  }
+  function remove() {
+    splash.style.opacity = "0";
+    setTimeout(function () { try { splash.remove(); } catch (e) {} }, 350);
+  }
+
+  if (document.body) mount();
+  else document.addEventListener("DOMContentLoaded", mount);
+
+  // chatroom 出現（訊息輸入框 = textarea / contenteditable，登入頁沒有）→ 立刻移除
+  var obs = new MutationObserver(function () {
+    if (document.querySelector('textarea, [contenteditable="true"]')) {
+      obs.disconnect();
+      remove();
+    }
+  });
+  document.addEventListener("DOMContentLoaded", function () {
+    mount();
+    obs.observe(document.body, { childList: true, subtree: true });
+  });
+
+  // 硬上限：4 秒一定移除（偵測失敗時不讓 splash 卡住）
+  setTimeout(function () { try { obs.disconnect(); } catch (e) {} remove(); }, 4000);
+})();


### PR DESCRIPTION
custom_js：有 eva_sso cookie 才蓋「登入中…」splash，chatroom 出現即移除；standalone 不受影響。前端是 Chainlit SPA→這是 splash 緩解（作者建議的替代），非深層改 render 順序。需瀏覽器驗視覺。🤖 Generated with [Claude Code](https://claude.com/claude-code)