### PR TITLE
fix(ui): 主題對 key + splash 用 hint cookie (#43)

### DIFF
--- a/.chainlit/config.toml
+++ b/.chainlit/config.toml
@@ -56,6 +56,9 @@ edit_message = true
 # Name of the assistant.
 name = "AI Eva"
 
+# 預設主題（Chainlit 讀這個 key，不是 [UI.theme].default）。只影響沒手動切過的新訪客。
+default_theme = "light"
+
 # Description of the assistant. This is used for HTML tags.
 # description = ""
 

--- a/app/surfaces/sso.py
+++ b/app/surfaces/sso.py
@@ -130,6 +130,12 @@ async def sso_handoff(token: str, request: Request):
         "eva_sso", sess["session_id"],
         httponly=True, secure=True, samesite="lax", max_age=_SESSION_TTL,
     )
+    # 非 HttpOnly 提示旗標：純給前端 custom.js 偵測「這是 SSO 來源」以蓋 splash（#43）。
+    # 不含 secret（只是 "1"），所以可被 JS 讀；真正的 session 仍在 HttpOnly 的 eva_sso。
+    resp.set_cookie(
+        "eva_sso_hint", "1",
+        httponly=False, secure=True, samesite="lax", max_age=_SESSION_TTL,
+    )
     return resp
 
 

--- a/public/custom.js
+++ b/public/custom.js
@@ -2,7 +2,8 @@
 // 避免 Chainlit SPA 先 render 登入表單再切 chatroom 的那一閃。
 // 只在有 eva_sso cookie 時動作 → 沒 session 的 standalone 訪客完全不受影響（照常看登入頁）。
 (function () {
-  if (!/(^|;\s*)eva_sso=/.test(document.cookie)) return;  // 非 SSO 來源 → 不蓋，standalone 照舊
+  // 用非 HttpOnly 的 eva_sso_hint 偵測（真正的 eva_sso 是 HttpOnly，JS 讀不到）。
+  if (!/(^|;\s*)eva_sso_hint=/.test(document.cookie)) return;  // 非 SSO 來源 → 不蓋，standalone 照舊
 
   var splash = document.createElement("div");
   splash.id = "eva-sso-splash";


### PR DESCRIPTION
上輪兩個疏失修正：(1) 主題 key 改對 [UI] default_theme=light；(2) eva_sso 是 HttpOnly JS 讀不到 → 加非-HttpOnly eva_sso_hint 給 splash 偵測。實測機制都對。主題需 fresh incognito 才見 light。🤖 Generated with [Claude Code](https://claude.com/claude-code)