### PR TITLE
fix(ui): custom.js cache-bust (#43)

### DIFF
--- a/.chainlit/config.toml
+++ b/.chainlit/config.toml
@@ -78,7 +78,8 @@ cot = "full"
 # Specify a Javascript file that can be used to customize the user interface.
 # The Javascript file can be served from the public directory.
 # #43: SSO 進站 splash（只在有 eva_sso cookie 時蓋「登入中…」，避免登入頁一閃；standalone 不受影響）
-custom_js = "/public/custom.js"
+# ?v= 是 cache-bust：custom.js 改版後瀏覽器會抓新的（同 URL 會用舊快取）。改 js 記得 bump。
+custom_js = "/public/custom.js?v=20260617b"
 
 # Specify a custom font url.
 # custom_font = "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"


### PR DESCRIPTION
splash 失效真因=瀏覽器快取舊 custom.js（headless 乾淨瀏覽器實測 splash 正常）。custom_js 加 ?v= 強制抓新。🤖 Generated with [Claude Code](https://claude.com/claude-code)