### PR TITLE
fix(ui): splash 撐到 settle 消側邊欄閃 (#43)

### DIFF
--- a/.chainlit/config.toml
+++ b/.chainlit/config.toml
@@ -79,7 +79,7 @@ cot = "full"
 # The Javascript file can be served from the public directory.
 # #43: SSO 進站 splash（只在有 eva_sso cookie 時蓋「登入中…」，避免登入頁一閃；standalone 不受影響）
 # ?v= 是 cache-bust：custom.js 改版後瀏覽器會抓新的（同 URL 會用舊快取）。改 js 記得 bump。
-custom_js = "/public/custom.js?v=20260617b"
+custom_js = "/public/custom.js?v=20260617c"
 
 # Specify a custom font url.
 # custom_font = "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"

--- a/public/custom.js
+++ b/public/custom.js
@@ -29,11 +29,12 @@
   if (document.body) mount();
   else document.addEventListener("DOMContentLoaded", mount);
 
-  // chatroom 出現（訊息輸入框 = textarea / contenteditable，登入頁沒有）→ 立刻移除
+  // chatroom 出現（訊息輸入框 = textarea / contenteditable，登入頁沒有）→ 再等版面 settle
+  // 才淡出。直接移除會瞥見側邊欄（過去7天/歷史）還在 hydrate 的那一閃。
   var obs = new MutationObserver(function () {
     if (document.querySelector('textarea, [contenteditable="true"]')) {
       obs.disconnect();
-      remove();
+      setTimeout(remove, 500);  // 留時間給 sidebar/layout 畫完
     }
   });
   document.addEventListener("DOMContentLoaded", function () {


### PR DESCRIPTION
splash 一偵測 chat 就淡→瞥見 sidebar hydrate。改成 chat 出現後 +500ms settle 才 remove。headless 實測 @1400ms 仍覆蓋。bump ?v=c。🤖 Generated with [Claude Code](https://claude.com/claude-code)