### PR TITLE
feat(copilot): 寫類 confirm→execute 迴圈 (#51)

### DIFF
--- a/app/core/copilot.py
+++ b/app/core/copilot.py
@@ -22,8 +22,28 @@ COPILOT_SYSTEM = (
     "不要臆測沒有的資訊。查到什麼就如實回答，查不到就說查不到。"
     "用繁體中文、簡潔。涉及需要確認的寫入操作時，先說明再請使用者確認。\n"
     "重要：當某工具需要專案 uuid 但使用者沒提供時，**先呼叫 list_my_projects 取得**，"
-    "再用拿到的 uuid 去查（例如查 SROI）。不要反過來要使用者提供 uuid。"
+    "再用拿到的 uuid 去查（例如查 SROI）。不要反過來要使用者提供 uuid。\n"
+    "建立專案（create_project）只需要『名稱』；使用者只給名稱時就**直接用名稱呼叫工具**，"
+    "不要追問主辦組織/預算等選填欄位（那些之後可再補）。"
 )
+
+
+def _confirm_question(name: str, args: dict) -> str:
+    """寫類工具待確認時，給使用者看的確認問句。"""
+    if name == "create_project":
+        return f"要建立專案「{args.get('name') or '（未命名）'}」嗎？確認後我就送出。"
+    summary = "、".join(f"{k}={v}" for k, v in list(args.items())[:5])
+    return f"要執行「{name}」嗎？（{summary}）確認後執行。"
+
+
+def _fmt_result(name: str, data) -> str:
+    """confirmed 執行成功後的回報。"""
+    if isinstance(data, dict):
+        inner = data.get("data", data)
+        uuid = (inner or {}).get("uuid") or (inner or {}).get("uuid_project")
+        if name == "create_project" and uuid:
+            return f"✅ 專案已建立，uuid：`{uuid}`。"
+    return f"✅ 完成。\n```\n{json.dumps(data, ensure_ascii=False)[:500]}\n```"
 
 
 async def run_copilot(
@@ -33,11 +53,12 @@ async def run_copilot(
     *,
     api_key: str | None = None,
     max_rounds: int = 4,
-) -> str:
-    """跑一輪副駕對話，回最終文字。
+) -> dict:
+    """跑一輪副駕對話。回 {"reply": str, "pending": {name,args}|None}。
 
-    runtime: 已 load(manifest) 的 ToolRuntime
-    history: 之前的 langchain messages（可選）
+    讀類工具直接執行；寫類工具（needs_confirm）→ **停下、回 pending**，
+    由 caller 出確認 UI，使用者同意後再以 confirmed=True 重打（execute_confirmed）。
+    runtime: 已 load(manifest) 的 ToolRuntime；history: 之前的 langchain messages。
     """
     tools = runtime.visible_tools()
     llm = make_llm(api_key=api_key, streaming=False)
@@ -54,17 +75,28 @@ async def run_copilot(
 
         tool_calls = getattr(resp, "tool_calls", None) or []
         if not tool_calls:
-            return (resp.content or "").strip() or "（這次沒拿到回應）"
+            return {"reply": (resp.content or "").strip() or "（這次沒拿到回應）", "pending": None}
 
         for tc in tool_calls:
             name, args, tc_id = tc.get("name", ""), tc.get("args") or {}, tc.get("id", "")
-            result = await runtime.execute(name, args, confirmed=False)  # 寫類不自動 confirm
+            result = await runtime.execute(name, args, confirmed=False)  # 先不 confirm
             logger.info("copilot tool %s(%s) → %s", name, args, result.get("status"))
+            if result.get("status") == "need_confirm":
+                # 寫類待確認：停下、把 pending 交給 caller（出確認鈕），不繼續這輪迴圈
+                return {"reply": _confirm_question(name, args), "pending": {"name": name, "args": args}}
             msgs.append(ToolMessage(
                 content=json.dumps(result, ensure_ascii=False),
                 tool_call_id=tc_id,
             ))
 
-    # 用完 max_rounds 還在叫工具 → 收尾要它直接回答
     final = await llm.ainvoke(msgs + [HumanMessage(content="請根據以上工具結果直接回答，不要再呼叫工具。")])
-    return (final.content or "").strip() or "（查了多輪仍未完成）"
+    return {"reply": (final.content or "").strip() or "（查了多輪仍未完成）", "pending": None}
+
+
+async def execute_confirmed(runtime, name: str, args: dict) -> str:
+    """使用者確認後，以 confirmed=True 真的執行 pending 寫類工具，回報結果。"""
+    result = await runtime.execute(name, args, confirmed=True)
+    logger.info("copilot confirmed %s(%s) → %s", name, args, result.get("status"))
+    if result.get("status") == "ok":
+        return _fmt_result(name, result.get("result"))
+    return f"⚠️ 執行失敗：{result.get('reason', result.get('status'))}"

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ from chainlit.data.sql_alchemy import SQLAlchemyDataLayer
 from langchain_core.messages import AIMessage, HumanMessage
 
 from app.apps._registry import chainlit_commands, default_app, discover, get_by_id
-from app.core.copilot import run_copilot
+from app.core.copilot import run_copilot, execute_confirmed
 from app.core.storage import LocalStorageClient
 from app.dispatch import Envelope, handle_device_intent
 from app.nodes import commands as node_commands
@@ -151,14 +151,25 @@ async def on_message(msg: cl.Message):
     runtime = cl.user_session.get("cms_runtime")
     if runtime is not None:
         history = cl.user_session.get("cms_history") or []
+        pending = None
         try:
-            ans = await run_copilot(runtime, content, history)
+            result = await run_copilot(runtime, content, history)
+            ans, pending = result["reply"], result.get("pending")
         except Exception as e:  # noqa: BLE001
             logger.exception("CMS copilot failed")
             ans = f"⚠️ 查詢失敗，請再試一次（{type(e).__name__}）"
         history += [HumanMessage(content=content), AIMessage(content=ans)]
         cl.user_session.set("cms_history", history[-12:])
-        await cl.Message(content=ans).send()
+        if pending:
+            # 寫類待確認：存 pending + 出確認鈕（confirm 控制訊號，避免 NLP 猜「好」）
+            cl.user_session.set("pending_tool", pending)
+            await cl.Message(content=ans, actions=[
+                cl.Action(name="cms_confirm", payload={"decision": "yes"}, label="✅ 確認"),
+                cl.Action(name="cms_confirm", payload={"decision": "no"}, label="✖ 取消"),
+            ]).send()
+        else:
+            cl.user_session.set("pending_tool", None)
+            await cl.Message(content=ans).send()
         return
 
     # 沒選特定工具時，先看是不是要指揮裝置（function-calling）。
@@ -194,3 +205,23 @@ async def on_message(msg: cl.Message):
 
     logger.info("dispatch → %s (command=%s, payload=%r)", app.id, msg.command, content[:60])
     await app.handle(content, msg)
+
+
+@cl.action_callback("cms_confirm")
+async def cms_confirm(action: cl.Action):
+    """使用者按確認鈕 → 對 pending 寫類工具以 confirmed=True 重打（#51）。"""
+    pending = cl.user_session.get("pending_tool")
+    runtime = cl.user_session.get("cms_runtime")
+    cl.user_session.set("pending_tool", None)
+    if not (pending and runtime):
+        await cl.Message(content="這個確認已失效，請重新說一次需求。").send()
+        return
+    if (action.payload or {}).get("decision") != "yes":
+        await cl.Message(content="好，已取消，沒有送出。").send()
+        return
+    try:
+        reply = await execute_confirmed(runtime, pending["name"], pending["args"])
+    except Exception as e:  # noqa: BLE001
+        logger.exception("CMS confirm execute failed")
+        reply = f"⚠️ 執行失敗（{type(e).__name__}）"
+    await cl.Message(content=reply).send()


### PR DESCRIPTION
run_copilot 回 {reply,pending}；寫類 need_confirm→停下回 pending→確認鈕→execute_confirmed(confirmed=True) 真執行。實測真 CMS：建專案→確認→回 uuid。讀類不受影響。closes #51。🤖 Generated with [Claude Code](https://claude.com/claude-code)